### PR TITLE
Feat/add support for container per aws profile

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,6 +10,10 @@ overrides: []
 globals:
   browser: true
   __dirname: true
+  # Common
+  loadAwsProfiles: true
+  saveAwsProfile: true
+  saveAwsProfiles: true
 parserOptions:
   ecmaVersion: latest
 rules: {}

--- a/src/background_scripts/background.js
+++ b/src/background_scripts/background.js
@@ -2,6 +2,22 @@ const REQUIRED_PERMISSIONS = {
   origins: ["https://*.amazonaws.com/federation/console*"],
 };
 
+const decoder = new TextDecoder("utf-8");
+const encoder = new TextEncoder();
+
+async function getOrCreateContainerForProfile(profile) {
+  const availableContainers = await browser.contextualIdentities.query({ name: profile.title });
+  if (availableContainers.length >= 1) {
+    return availableContainers[0];
+  } else {
+    return browser.contextualIdentities.create({
+      name: profile.title,
+      color: profile.color,
+      icon: "briefcase",
+    });
+  }
+}
+
 function extractProfileInfoFromRequest(requestDetails) {
   const url = new URL(requestDetails.url);
   const profileName = url.searchParams.get("role_name");
@@ -24,28 +40,84 @@ function extractProfileInfoFromRequest(requestDetails) {
   return profileInfo;
 }
 
-async function signInfoRequestListener(requestDetails) {
-  const awsProfile = extractProfileInfoFromRequest(requestDetails);
-  await saveAwsProfile(awsProfile);
+function buildProfileLoginUrl(profile, signInInfo) {
+  const destination = signInInfo.destination || "https://console.aws.amazon.com/";
+  const queryParameters = new URLSearchParams({
+    Action: "login",
+    SigninToken: signInInfo.signInToken,
+    Issuer: profile.url,
+    Destination: destination,
+  });
+  const loginUrl = `${signInInfo.signInFederationLocation}?${queryParameters.toString()}`;
+  return loginUrl;
+}
+
+async function saveAwsProfileRequestListener(requestDetails) {
+  await saveAwsProfile(extractProfileInfoFromRequest(requestDetails));
+}
+
+async function openProfileInContainerRequestListener(requestDetails) {
+  const awsProfile = await saveAwsProfile(extractProfileInfoFromRequest(requestDetails));
+
+  if (requestDetails.method != "GET") return {};
+
+  const requestFilterStream = browser.webRequest.filterResponseData(requestDetails.requestId);
+
+  const responseBufferArray = [];
+  requestFilterStream.ondata = (event) => {
+    responseBufferArray.push(decoder.decode(event.data, { stream: true }));
+  };
+
+  requestFilterStream.onstop = async () => {
+    const responseData = responseBufferArray.join("");
+    try {
+      const signInInfo = JSON.parse(responseData);
+      const url = buildProfileLoginUrl(awsProfile, signInInfo);
+      const container = await getOrCreateContainerForProfile(awsProfile);
+      await Promise.all([
+        browser.tabs.create({ url, cookieStoreId: container.cookieStoreId }),
+        browser.tabs.remove(requestDetails.tabId),
+      ]);
+    } catch {
+      // If anything goes wrong, we passthrough to avoid blocking anything
+      requestFilterStream.write(encoder.encode(responseData));
+    } finally {
+      requestFilterStream.close();
+    }
+  };
   return {};
 }
 
 async function configureListener() {
-  const configuration = (await browser.storage.local.get({ configuration: {} })).configuration;
-  const hasPermissions = await browser.permissions.contains(REQUIRED_PERMISSIONS);
-  const alreadyRegistered = browser.webRequest.onBeforeRequest.hasListener(signInfoRequestListener);
+  // We reset the state before re-configuring
+  [saveAwsProfileRequestListener, openProfileInContainerRequestListener].forEach((listener) => {
+    if (browser.webRequest.onBeforeRequest.hasListener(listener)) {
+      browser.webRequest.onBeforeRequest.removeListener(listener);
+    }
+  });
+  if (!(await browser.permissions.contains(REQUIRED_PERMISSIONS))) {
+    return;
+  }
 
-  if (configuration.autoPopulateUsedProfiles && hasPermissions) {
-    if (!alreadyRegistered) {
-      browser.webRequest.onBeforeRequest.addListener(signInfoRequestListener, {
+  const configuration = (await browser.storage.local.get({ configuration: {} })).configuration;
+
+  if (configuration.openProfileInDedicatedContainer && configuration.autoPopulateUsedProfiles) {
+    browser.webRequest.onBeforeRequest.addListener(
+      openProfileInContainerRequestListener,
+      {
         urls: REQUIRED_PERMISSIONS["origins"],
         types: ["xmlhttprequest"],
-      });
-    }
-  } else {
-    if (alreadyRegistered) {
-      browser.webRequest.onBeforeRequest.removeListener(signInfoRequestListener);
-    }
+      },
+      ["blocking"]
+    );
+  } else if (configuration.autoPopulateUsedProfiles) {
+    // The openProfileInContainerRequestListener will also save any aws profile encountered
+    // so we only enable the saveAwsProfileRequestListener one if the listener
+    // openProfileInContainerRequestListener is not set
+    browser.webRequest.onBeforeRequest.addListener(saveAwsProfileRequestListener, {
+      urls: REQUIRED_PERMISSIONS["origins"],
+      types: ["xmlhttprequest"],
+    });
   }
 }
 

--- a/src/background_scripts/background.js
+++ b/src/background_scripts/background.js
@@ -24,16 +24,9 @@ function extractProfileInfoFromRequest(requestDetails) {
   return profileInfo;
 }
 
-async function saveAwsProfile(awsProfile) {
-  const storageContent = await browser.storage.local.get({ awsProfiles: {} });
-  const existingAwsProfile = storageContent.awsProfiles[awsProfile.id] || {};
-  storageContent.awsProfiles[awsProfile.id] = Object.assign({}, existingAwsProfile, awsProfile);
-  await browser.storage.local.set(storageContent);
-}
-
-function signInfoRequestListener(requestDetails) {
+async function signInfoRequestListener(requestDetails) {
   const awsProfile = extractProfileInfoFromRequest(requestDetails);
-  saveAwsProfile(awsProfile);
+  await saveAwsProfile(awsProfile);
   return {};
 }
 

--- a/src/content_scripts/profiles_info_loader.js
+++ b/src/content_scripts/profiles_info_loader.js
@@ -70,17 +70,6 @@ function extractAwsProfilesFromAllAccountSections(awsAccountSections) {
   return awsAccountSections.map(extractAwsProfilesFromAccountSection).flat();
 }
 
-async function saveAwsProfiles(awsProfiles) {
-  const currentStorage = await browser.storage.local.get({ awsProfiles: {} });
-
-  awsProfiles.forEach((profile) => {
-    const existingAwsProfile = currentStorage.awsProfiles[profile.id] || {};
-    currentStorage.awsProfiles[profile.id] = Object.assign({}, existingAwsProfile, profile);
-  });
-
-  await browser.storage.local.set(currentStorage);
-}
-
 /*******************************************************************************
  * Main code
  *******************************************************************************/

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -61,7 +61,9 @@ async function loadAwsProfiles() {
     await browser.storage.local.remove("awsProfilesByDomain");
   }
   const storageContent = await browser.storage.local.get({ awsProfiles: {} });
-  const awsProfiles = Object.values(storageContent.awsProfiles).sort();
+  const awsProfiles = Object.values(storageContent.awsProfiles).sort((a, b) =>
+    a.title.localeCompare(b.title)
+  );
   return awsProfiles;
 }
 

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -1,0 +1,50 @@
+async function saveAwsProfile(awsProfile) {
+  const storageContent = await browser.storage.local.get({ awsProfiles: {} });
+  const existingAwsProfile = storageContent.awsProfiles[awsProfile.id] || {};
+  storageContent.awsProfiles[awsProfile.id] = Object.assign({}, existingAwsProfile, awsProfile);
+  await browser.storage.local.set(storageContent);
+}
+
+async function saveAwsProfiles(awsProfiles) {
+  const currentStorage = await browser.storage.local.get({ awsProfiles: {} });
+
+  awsProfiles.forEach((profile) => {
+    const existingAwsProfile = currentStorage.awsProfiles[profile.id] || {};
+    currentStorage.awsProfiles[profile.id] = Object.assign({}, existingAwsProfile, profile);
+  });
+
+  await browser.storage.local.set(currentStorage);
+}
+
+async function legacyLoadAwsProfiles() {
+  const storageContent = await browser.storage.local.get({ awsProfilesByDomain: {} });
+
+  const awsProfiles = Object.values(storageContent.awsProfilesByDomain)
+    .map((awsAccountProfiles) => Object.values(awsAccountProfiles.awsProfilesByAccount))
+    .flat()
+    .map((awsProfilesByAccount) => Object.values(awsProfilesByAccount.awsProfilesByName))
+    .flat()
+    .map((profile) => Object.assign(profile, { id: `${profile.portalDomain} - ${profile.title}` }));
+
+  return awsProfiles;
+}
+
+async function loadAwsProfiles() {
+  const legacyAwsProfiles = await legacyLoadAwsProfiles();
+  if (legacyAwsProfiles.length > 0) {
+    saveAwsProfiles(legacyAwsProfiles);
+    await browser.storage.local.remove("awsProfilesByDomain");
+  }
+  const storageContent = await browser.storage.local.get({ awsProfiles: {} });
+  const awsProfiles = Object.values(storageContent.awsProfiles).sort();
+  return awsProfiles;
+}
+
+// eslint-disable-next-line no-unused-vars
+const common = {
+  loadAwsProfiles,
+  saveAwsProfile,
+  saveAwsProfiles,
+};
+
+exports = common;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,7 +26,8 @@
         "contextualIdentities",
         "cookies",
         "storage",
-        "webRequest"
+        "webRequest",
+        "webRequestBlocking"
     ],
     "optional_permissions": [
         "https://*.amazonaws.com/federation/console*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,6 +34,7 @@
     ],
     "background": {
         "scripts": [
+            "lib/common.js",
             "background_scripts/background.js"
         ],
         "persistent": true

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -13,7 +13,7 @@
         <p>
           <label>
             <input type="checkbox" id="auto-populate-used-profiles" />
-            <span class="bold">Auto-populate used AWS profiles</span>
+            <span class="bold">Automatically add AWS profiles being used to the switcher list</span>
           </label>
         </p>
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -16,12 +16,21 @@
             <span class="bold">Automatically add AWS profiles being used to the switcher list</span>
           </label>
         </p>
-
         <p>
-          <em
-            >This option requires additional permissions to access data in the awsapps.com
-            domain</em
-          >
+          <em>
+            This option requires additional permissions to access data in the awsapps.com domain
+          </em>
+        </p>
+      </div>
+      <div class="settings-group">
+        <p>
+          <label>
+            <input type="checkbox" id="openProfileInDedicatedContainer" />
+            <span class="bold">Open each AWS profile in a dedicated container</span>
+          </label>
+        </p>
+        <p>
+          <em>This option requires the "Automatically add AWS profiles" option to be enabled</em>
         </p>
       </div>
     </form>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -12,7 +12,7 @@
       <div class="settings-group">
         <p>
           <label>
-            <input type="checkbox" id="auto-populate-used-profiles" />
+            <input type="checkbox" id="autoPopulateUsedProfiles" />
             <span class="bold">Automatically add AWS profiles being used to the switcher list</span>
           </label>
         </p>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -45,6 +45,21 @@ async function setupOptionsUI() {
     preEnableOption: () => browser.permissions.request(PERMISSIONS),
     postDisableOption: () => setOptionState("openProfileInDedicatedContainer", false),
   });
+
+  await configureOption("openProfileInDedicatedContainer", {
+    confirmOptionEnabled: async () => {
+      return (
+        (await browser.permissions.contains(PERMISSIONS)) &&
+        (await isOptionEnabled("autoPopulateUsedProfiles"))
+      );
+    },
+    preEnableOption: async () => {
+      return (
+        (await browser.permissions.request(PERMISSIONS)) &&
+        (await setOptionState("autoPopulateUsedProfiles", true))
+      );
+    },
+  });
 }
 
 setupOptionsUI();

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -49,6 +49,7 @@
       </div>
     </div>
 
+    <script src="../lib/common.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -2,30 +2,19 @@
  * Helper functions
  *******************************************************************************/
 
-function getNiceColor(index) {
-  const niceColors = [
-    "#ea5545",
-    "#f46a9b",
-    "#ef9b20",
-    "#edbf33",
-    "#ede15b",
-    "#bdcf32",
-    "#87bc45",
-    "#27aeef",
-    "#b33dc6",
-    "#964b00",
-    "#8b008b",
-    "#1e90ff",
-    "#ffd700",
-    "#228b22",
-    "#00ffff",
-    "#ff69b4",
-    "#ffa07a",
-    "#8fbc8f",
-    "#483d8b",
-    "#00bfff",
-  ];
-  return niceColors[index % niceColors.length];
+const HTML_COLOR_CODE = {
+  blue: "#37adff",
+  turquoise: "#00c79a",
+  green: "#51cd00",
+  yellow: "#ffcb00",
+  orange: "#ff9f00",
+  red: "#ff613d",
+  pink: "#ff4bda",
+  purple: "#af51f5",
+};
+
+function getHtmlColorCode(colorName) {
+  return HTML_COLOR_CODE[colorName];
 }
 
 function getColorThemePreference() {
@@ -79,10 +68,10 @@ function createElement(tagName, { classes = [], attributes = {}, text }) {
   return element;
 }
 
-function createTableEntryFromAwsProfile(awsProfile, index) {
+function createTableEntryFromAwsProfile(awsProfile) {
   const entry = createElement("div", { classes: ["profile-item"] });
   if (awsProfile.favorite) entry.classList.add("profile-favorite");
-  const dotStyle = `background-color: ${getNiceColor(index)}`;
+  const dotStyle = `background-color: ${getHtmlColorCode(awsProfile.color)}`;
   entry.append(
     createElement("div", { classes: ["profile-dot"], attributes: { style: dotStyle } }),
     createElement("div", { classes: ["profile-text"], text: awsProfile.title }),

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,23 +1,50 @@
-const { createFakeBrowser, buildStorageContentForDomains } = require("./helper");
+const path = require("path");
+
+const { buildStorageContentForDomains, createFakePage, mockBrowserStorage } = require("./helper");
+
+/*******************************************************************************
+ * Constants
+ *******************************************************************************/
 
 const FAKE_DOMAIN = "ssodomain";
 
+const SRC_FOLDER = path.join(__dirname, "..", "src");
 const ALL_TEST_PROFILES = Object.values(buildStorageContentForDomains(FAKE_DOMAIN).awsProfiles);
 const TEST_PROFILE = ALL_TEST_PROFILES[0];
 
+const EMPTY_HTML = path.join(__dirname, "test_files", "empty.html");
+const BACKGROUND_SCRIPTS = [
+  `file://${path.join(SRC_FOLDER, "lib/common.js")}`,
+  `file://${path.join(SRC_FOLDER, "background_scripts/background.js")}`,
+];
+
+/*******************************************************************************
+ * Test Helper functions
+ *******************************************************************************/
+
+const listenerConfigured = (page) => async () => {
+  return page.window.browser.webRequest.onBeforeRequest.getListener() != null;
+};
+
+/*******************************************************************************
+ * Tests definition
+ *******************************************************************************/
+
 test("Auto-populate with an AWS profile used by the user", async () => {
   // Given
-  const browser = (global.browser = createFakeBrowser());
-  browser.storage.local.set({ configuration: { autoPopulateUsedProfiles: true } });
+  const browserStorage = mockBrowserStorage({ configuration: { autoPopulateUsedProfiles: true } });
+  const page = await createFakePage(EMPTY_HTML, { browserStorage });
+  await page.injectScripts(BACKGROUND_SCRIPTS, { waitCondition: listenerConfigured(page) });
+
+  // When
   const requestDetails = {
     url: `https://portal.sso.eu-west-1.amazonaws.com/federation/console?account_id=${TEST_PROFILE.accountId}&role_name=${TEST_PROFILE.name}`,
     originUrl: TEST_PROFILE.url,
   };
-  // When
-  require("../src/background_scripts/background");
-  const requestListener = await browser.webRequest.onBeforeRequest.waitForListener();
-  requestListener(requestDetails);
+  const requestListener = await page.window.browser.webRequest.onBeforeRequest.getListener();
+  await requestListener(requestDetails);
+
   // Then
-  const storageContent = await browser.storage.local.get();
+  const storageContent = await page.window.browser.storage.local.get();
   expect(storageContent.awsProfiles).toEqual({ [TEST_PROFILE.id]: TEST_PROFILE });
 });

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -32,16 +32,6 @@ const buildStorageContentForDomains = (...domains) => {
         id: `${domain} - Development - AdministratorAccess`,
       },
       {
-        accountName: "Production",
-        accountId: "123456789012",
-        color: colors[4 * index + 1],
-        name: "AdministratorAccess",
-        portalDomain: domain,
-        title: "Production - AdministratorAccess",
-        url: `https://${domain}.awsapps.com/start/#/saml/custom/123456789012%20%28Production%29/MTIzNDU2Nzg5MDEyX2lucy1jMjQ2ZGY4OWUwMTJhYjM1X3AtOTg3NmEyYjM5NDBjNWQ2ZQ%3D%3D`,
-        id: `${domain} - Production - AdministratorAccess`,
-      },
-      {
         accountName: "Root",
         accountId: "234567890123",
         color: colors[4 * index + 2],
@@ -60,6 +50,16 @@ const buildStorageContentForDomains = (...domains) => {
         title: "Root - ReadOnlyAccess",
         url: `https://${domain}.awsapps.com/start/#/saml/custom/234567890123%20%28Root%29/MjM0NTY3ODkwMTIzX2lucy1kMTM1YWM1N2UyNDZiODAzX3AtNWExYjJjM2Q0ZTVmNmc3aA%3D%3D`,
         id: `${domain} - Root - ReadOnlyAccess`,
+      },
+      {
+        accountName: "Production",
+        accountId: "123456789012",
+        color: colors[4 * index + 1],
+        name: "AdministratorAccess",
+        portalDomain: domain,
+        title: "Production - AdministratorAccess",
+        url: `https://${domain}.awsapps.com/start/#/saml/custom/123456789012%20%28Production%29/MTIzNDU2Nzg5MDEyX2lucy1jMjQ2ZGY4OWUwMTJhYjM1X3AtOTg3NmEyYjM5NDBjNWQ2ZQ%3D%3D`,
+        id: `${domain} - Production - AdministratorAccess`,
       },
     ];
     profiles.forEach((profile) => {

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -15,12 +15,14 @@ const waitForCondition = async (condition, timeout = 1000) => {
 };
 
 const buildStorageContentForDomains = (...domains) => {
+  const colors = ["blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple"];
   const storageContent = { awsProfiles: {} };
-  domains.forEach((domain) => {
+  domains.forEach((domain, index) => {
     const profiles = [
       {
         accountName: "Development",
         accountId: "987654321098",
+        color: colors[4 * index],
         name: "AdministratorAccess",
         portalDomain: domain,
         title: "Development - AdministratorAccess",
@@ -30,6 +32,7 @@ const buildStorageContentForDomains = (...domains) => {
       {
         accountName: "Production",
         accountId: "123456789012",
+        color: colors[4 * index + 1],
         name: "AdministratorAccess",
         portalDomain: domain,
         title: "Production - AdministratorAccess",
@@ -39,6 +42,7 @@ const buildStorageContentForDomains = (...domains) => {
       {
         accountName: "Root",
         accountId: "234567890123",
+        color: colors[4 * index + 2],
         name: "AdministratorAccess",
         portalDomain: domain,
         title: "Root - AdministratorAccess",
@@ -48,6 +52,7 @@ const buildStorageContentForDomains = (...domains) => {
       {
         accountName: "Root",
         accountId: "234567890123",
+        color: colors[4 * index + 3],
         name: "ReadOnlyAccess",
         portalDomain: domain,
         title: "Root - ReadOnlyAccess",

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -51,7 +51,7 @@ test("Load and display roles from storage", async () => {
     "Root - AdministratorAccess",
     "Root - ReadOnlyAccess",
   ]);
-  expect(favoriteProfileDiv.textContent).toMatch(favoriteProfile.title);
+  expect(favoriteProfileDiv.textContent).toEqual(favoriteProfile.title);
 });
 
 test("Display instructions when no profiles exist", async () => {

--- a/tests/profiles_info_loader.test.js
+++ b/tests/profiles_info_loader.test.js
@@ -82,14 +82,14 @@ test.each(testFiles)("Parse correctly AWS Portal page with $case", async ({ html
   await awsPortalPage.injectScriptsAndWaitForStorageUpdate(PROFILES_INFO_LOADER_SCRIPTS);
   // Then
   const browserStorageContent = await awsPortalPage.window.browser.storage.local.get();
-  expect(browserStorageContent).toMatchObject(buildStorageContentForDomains("mysso"));
+  expect(browserStorageContent).toEqual(buildStorageContentForDomains("mysso"));
 });
 
 test("Merge profiles from two different AWS Portal pages in storage", async () => {
   // Given
   const browserStorage = mockBrowserStorage();
   const awsPortalPages = await Promise.all(
-    ["anothersso", "mysso"].map((domain) =>
+    ["mysso", "anothersso"].map((domain) =>
       createFakeAwsPortalPage(`aws_portal.${domain}.html`, { browserStorage })
     )
   );
@@ -100,7 +100,7 @@ test("Merge profiles from two different AWS Portal pages in storage", async () =
   // Then
   const browserStorageContent = await browserStorage.get();
   const expectedContent = buildStorageContentForDomains("mysso", "anothersso");
-  expect(browserStorageContent).toMatchObject(expectedContent);
+  expect(browserStorageContent).toEqual(expectedContent);
 });
 
 test("Update profiles fom an existing AWS Portal pages in storage", async () => {
@@ -123,5 +123,5 @@ test("Update profiles fom an existing AWS Portal pages in storage", async () => 
   await awsPortalPage.injectScriptsAndWaitForStorageUpdate(PROFILES_INFO_LOADER_SCRIPTS);
   // Then
   const browserStorageContent = await awsPortalPage.window.browser.storage.local.get();
-  expect(browserStorageContent).toMatchObject(expectedContent);
+  expect(browserStorageContent).toEqual(expectedContent);
 });

--- a/tests/test_files/empty.html
+++ b/tests/test_files/empty.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body></body>
+</html>


### PR DESCRIPTION
The initial idea was to just open directly the profile url in a new container but, if we do so, we can't share the authentication session between all the profile containers and one has to re-auth for each profile container.

To be able to share the authentication session, we now intercept the request used to obtain the sign-in token. This request is done after successful authentication has been performed in the sso portal page, and the sign-in token allows us to build a sign-in url that we can just pass to the new container to successfully open the new profile in another container.