### PR TITLE
:bug: Workaround 429 rate limit error when loading profiles

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,7 @@ globals:
   loadAwsProfiles: true
   saveAwsProfile: true
   saveAwsProfiles: true
+  removeAwsProfilesForPortalDomain: true
 parserOptions:
   ecmaVersion: latest
 rules: {}

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -85,7 +85,6 @@ function createTableEntryFromAwsProfile(awsProfile) {
 }
 
 async function loadProfilesFromPortalPage() {
-  browser.storage.onChanged.addListener(refreshPopupDisplay);
   await browser.tabs.executeScript({ file: "/lib/common.js" });
   await browser.tabs.executeScript({ file: "/content_scripts/profiles_info_loader.js" });
 }
@@ -124,8 +123,6 @@ async function refreshPopupDisplay() {
   setPopupSectionVisibility("aws-access-portal", isOnAwsPortal);
   setPopupSectionVisibility("no-profile-info", !hasProfiles && !isOnAwsPortal);
   setPopupSectionVisibility("profiles", hasProfiles);
-
-  browser.storage.onChanged.removeListener(refreshPopupDisplay);
 }
 
 function installEventHandlers() {
@@ -148,3 +145,5 @@ refreshPopupDisplay().then(() => {
   installEventHandlers();
   document.querySelector("input#searchbox").focus();
 });
+
+browser.storage.onChanged.addListener(refreshPopupDisplay);

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -69,6 +69,7 @@ test("Auto-populate with an AWS profile used by the user", async () => {
     configuration: { autoPopulateUsedProfiles: true },
   });
   // When
+  await browser.webRequest.onBeforeRequest.waitForListener();
   await browser.webRequest.onBeforeRequest.triggerListener(TEST_PROFILE_LOGIN_REQUEST);
   // Then
   const storageContent = await browser.storage.local.get();

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -103,6 +103,7 @@ const createFakeBrowser = (browserStorage, tabUrl) => {
       local: browserStorage || mockBrowserStorage(),
       onChanged: {
         removeListener: () => {},
+        addListener: () => {},
       },
     },
     tabs: {
@@ -212,7 +213,7 @@ const createFakePage = async (
     return { matches: true };
   };
 
-  dom.injectScripts = async (scripts, { waitCondition, waitTimeout } = {}) => {
+  dom.injectScripts = async (scripts) => {
     const scriptLoaders = scripts.map(
       (script) =>
         new Promise((resolve) => {
@@ -223,7 +224,6 @@ const createFakePage = async (
         })
     );
     await Promise.all(scriptLoaders);
-    await waitForCondition(waitCondition, waitTimeout);
   };
 
   // Workaround the issue that jsdom doesn't define these 2 ones


### PR DESCRIPTION
AWS recently introduced rate liming for call to its SSO portal frontend API. This can cause failure to load all profiles or can prevent subsequent profiles loading to work as 429 response is returned.

To avoid triggering the error, we now load the profiles sequentially from the SSO portal page.