### PR TITLE
:bug: fix breakage caused by new AWS Access Portal design

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,7 @@ globals:
   browser: true
   __dirname: true
   # Common
+  AwsProfile: true
   loadAwsProfiles: true
   saveAwsProfile: true
   saveAwsProfiles: true

--- a/src/content_scripts/profiles_info_loader.js
+++ b/src/content_scripts/profiles_info_loader.js
@@ -8,7 +8,24 @@ async function waitFor(ms) {
   });
 }
 
-async function expandSection(section) {
+/*******************************************************************************
+ * Common AWS Console functions
+ ******************************************************************************/
+
+function findAwsPortalDomain() {
+  const domain = new URL(window.location.href).host.replace(".awsapps.com", "");
+  return domain;
+}
+
+function findPortalStyle(page) {
+  return page.querySelector('div[data-testid="account-list"]') ? "new" : "legacy";
+}
+
+/*******************************************************************************
+ * Legacy AWS Console functions
+ ******************************************************************************/
+
+async function expandSectionLegacy(section) {
   let expanded = section.querySelector("sso-expander") !== null;
   let expandAnimationMarker = section.querySelector("sso-line-loader") !== null;
   if (!expanded) {
@@ -23,28 +40,23 @@ async function expandSection(section) {
   return section;
 }
 
-function findAwsAccountsParentSection(page) {
+function findAwsAccountsParentSectionLegacy(page) {
   return page.querySelector("portal-application[title='AWS Account']").parentElement;
 }
 
-function findAwsAccountSections(accountsParentSection) {
+function findAwsAccountSectionsLegacy(accountsParentSection) {
   return Array.from(accountsParentSection.querySelectorAll("div.portal-instance-section"));
 }
 
-function findAwsProfileLinks(section) {
+function findAwsProfileLinksLegacy(section) {
   return Array.from(section.querySelectorAll("a.profile-link"));
 }
 
-function findAwsPortalDomain() {
-  const domain = new URL(window.location.href).host.replace(".awsapps.com", "");
-  return domain;
-}
-
-function extractAwsProfilesFromAccountSection(section) {
+function extractAwsProfilesFromAccountSectionLegacy(section) {
   const accountName = section.querySelector("div.name").textContent.trim();
   const accountId = section.querySelector("span.accountId").textContent.trim().replace("#", "");
   const portalDomain = findAwsPortalDomain();
-  const awsProfiles = findAwsProfileLinks(section).map((link) => {
+  const awsProfiles = findAwsProfileLinksLegacy(section).map((link) => {
     const name = link.getAttribute("title");
     const url = link.getAttribute("href");
     const title = `${accountName} - ${name}`;
@@ -54,15 +66,74 @@ function extractAwsProfilesFromAccountSection(section) {
   return awsProfiles;
 }
 
+async function* findAndExpandAwsAccountSectionFoldsLegacy(page) {
+  const accountsParentSection = findAwsAccountsParentSectionLegacy(page);
+  await expandSectionLegacy(accountsParentSection);
+  const accountSections = findAwsAccountSectionsLegacy(accountsParentSection);
+  // We open section sequentially with a small delay to avoid triggering
+  // the 429 too many requests error from AWS SSO Portal
+  for (const section of accountSections) {
+    yield expandSectionLegacy(section);
+    await waitFor(50);
+  }
+  return accountSections;
+}
+
+/*******************************************************************************
+ * New AWS Console functions
+ ******************************************************************************/
+
+function findAwsAccountSections(page) {
+  return Array.from(page.querySelectorAll('button[data-testid="account-list-cell"]')).map(
+    (elt) => elt.parentElement
+  );
+}
+
+async function expandSection(section) {
+  const expandButton = section.querySelector("button");
+  let expanded = expandButton.getAttribute("aria-expanded") === "true";
+  let expandAnimationMarker =
+    section.querySelector('span[data-testid="account-list-cell-loading"') !== null;
+  if (!expanded) {
+    expandButton.click();
+  }
+  while (!expanded || expandAnimationMarker) {
+    await waitFor(50);
+    expanded = expandButton.getAttribute("aria-expanded") === "true";
+    expandAnimationMarker =
+      section.querySelector('span[data-testid="account-list-cell-loading"') !== null;
+  }
+  return section;
+}
+function findAwsProfileLinks(section) {
+  return Array.from(section.querySelectorAll('a[data-testid="federation-link"]'));
+}
+
+function extractAwsProfilesFromAccountSection(section) {
+  const accountName = section.querySelector("strong").textContent.trim();
+  const portalDomain = findAwsPortalDomain();
+  const awsProfiles = findAwsProfileLinks(section).map((link) => {
+    const profileUrl = new URL(link.getAttribute("href"), window.location.href);
+    // The url parameters are not real query parameters as they are after the #
+    // but we can still use URLSearchParams to parse them
+    const profileUrlParams = new URLSearchParams(profileUrl.href.split("?")[1]);
+    const name = profileUrlParams.get("role_name");
+    const accountId = profileUrlParams.get("account_id");
+    const url = profileUrl.href;
+    const title = `${accountName} - ${name}`;
+    const id = `${portalDomain} - ${title}`;
+    return { portalDomain, accountName, accountId, name, url, title, id };
+  });
+  return awsProfiles;
+}
+
 async function* findAndExpandAwsAccountSectionFolds(page) {
-  const accountsParentSection = findAwsAccountsParentSection(page);
-  await expandSection(accountsParentSection);
-  const accountSections = findAwsAccountSections(accountsParentSection);
+  const accountSections = findAwsAccountSections(page);
   // We open section sequentially with a small delay to avoid triggering
   // the 429 too many requests error from AWS SSO Portal
   for (const section of accountSections) {
     yield expandSection(section);
-    await waitFor(50);
+    await waitFor(200);
   }
   return accountSections;
 }
@@ -71,15 +142,29 @@ async function* findAndExpandAwsAccountSectionFolds(page) {
  * Main code
  *******************************************************************************/
 
+const portalParsers = {
+  legacy: {
+    findAndExpandAwsAccountSectionFolds: findAndExpandAwsAccountSectionFoldsLegacy,
+    extractAwsProfilesFromAccountSection: extractAwsProfilesFromAccountSectionLegacy,
+  },
+  new: {
+    findAndExpandAwsAccountSectionFolds: findAndExpandAwsAccountSectionFolds,
+    extractAwsProfilesFromAccountSection: extractAwsProfilesFromAccountSection,
+  },
+};
+
 (async () => {
   const profilesRemoved = await removeAwsProfilesForPortalDomain(findAwsPortalDomain());
   const mergeWithPreviousProfileToKeepSettings = (profile) =>
     Object.assign({}, profilesRemoved[profile.id] || {}, profile);
 
-  for await (let section of findAndExpandAwsAccountSectionFolds(document)) {
-    const profiles = extractAwsProfilesFromAccountSection(section).map(
-      mergeWithPreviousProfileToKeepSettings
-    );
+  const portalStyle = findPortalStyle(document);
+  const portalParser = portalParsers[portalStyle];
+
+  for await (let section of portalParser.findAndExpandAwsAccountSectionFolds(document)) {
+    const profiles = portalParser
+      .extractAwsProfilesFromAccountSection(section)
+      .map(mergeWithPreviousProfileToKeepSettings);
     await saveAwsProfiles(profiles);
   }
 })();

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -23,6 +23,25 @@ async function saveAwsProfiles(newAwsProfiles) {
 
   newAwsProfiles.sort().forEach((profile) => {
     const color = getNextProfileColor(Object.keys(awsProfiles).length);
+
+    if (!(profile.id in awsProfiles)) {
+      // Starting with new AWS access portal layout, we might not get the account name
+      // when intercepting account connection URL, it is unfortunate as we would display
+      // the account id instead of the account name in the popup and container name.
+      // To workaround that, we try to find if the profile with same name and account id
+      // has already been saved when loading explicitely profiles from the portal page so
+      // we can retrieve the account name and fix the id and title
+      const isSameProfile = (p) =>
+        p.portalDomain === profile.portalDomain &&
+        p.accountId === profile.accountId &&
+        p.name === profile.name;
+      const sameProfile = Object.values(awsProfiles).find(isSameProfile);
+      if (sameProfile) {
+        profile.id = sameProfile.id;
+        profile.title = sameProfile.title;
+        profile.accountName = sameProfile.accountName;
+      }
+    }
     awsProfiles[profile.id] = Object.assign({ color }, profile);
   });
 

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -6,11 +6,11 @@ const { buildStorageContentForDomains, createFakePage, mockBrowserStorage } = re
  * Constants
  *******************************************************************************/
 
+const PORTAL_STYLES = ["legacy", "new"];
+
 const FAKE_DOMAIN = "ssodomain";
 
 const SRC_FOLDER = path.join(__dirname, "..", "src");
-const ALL_TEST_PROFILES = Object.values(buildStorageContentForDomains(FAKE_DOMAIN).awsProfiles);
-const TEST_PROFILE = ALL_TEST_PROFILES[0];
 
 const EMPTY_HTML = path.join(__dirname, "test_files", "empty.html");
 const BACKGROUND_SCRIPTS = [
@@ -40,72 +40,98 @@ const setupBrowserWithBackgroundScripts = async ({ configuration }) => {
 const TEST_FEDERATION_LOCATION = "https://eu-west-1.signin.aws.amazon.com/federation";
 const TEST_SIGNIN_TOKEN = "TEST_SIGNIN_TOKEN";
 
-const TEST_PROFILE_SIGNIN_URL =
-  `${TEST_FEDERATION_LOCATION}?` +
-  new URLSearchParams({
-    Action: "login",
-    SigninToken: TEST_SIGNIN_TOKEN,
-    Issuer: TEST_PROFILE.url,
-    Destination: "https://console.aws.amazon.com/",
-  }).toString();
+const getTestData = (portalStyle) => {
+  const testProfile = Object.values(
+    buildStorageContentForDomains(portalStyle, FAKE_DOMAIN).awsProfiles
+  )[0];
+  if (portalStyle === "new") {
+    testProfile.title = `${testProfile.accountId} - ${testProfile.name}`;
+    testProfile.id = `${testProfile.portalDomain} - ${testProfile.accountId} - ${testProfile.name}`;
+    testProfile.accountName = testProfile.accountId;
+  }
 
-const TEST_PROFILE_LOGIN_REQUEST = {
-  url: `https://portal.sso.eu-west-1.amazonaws.com/federation/console?account_id=${TEST_PROFILE.accountId}&role_name=${TEST_PROFILE.name}`,
-  originUrl: TEST_PROFILE.url,
-  method: "GET",
+  return {
+    profile: testProfile,
+    signinUrl:
+      `${TEST_FEDERATION_LOCATION}?` +
+      new URLSearchParams({
+        Action: "login",
+        SigninToken: TEST_SIGNIN_TOKEN,
+        Issuer: testProfile.url,
+        Destination: "https://console.aws.amazon.com/",
+      }).toString(),
+
+    loginRequest: {
+      url: `https://portal.sso.eu-west-1.amazonaws.com/federation/console?account_id=${testProfile.accountId}&role_name=${testProfile.name}`,
+      originUrl: testProfile.url,
+      method: "GET",
+    },
+    loginResponse: JSON.stringify({
+      signInToken: TEST_SIGNIN_TOKEN,
+      signInFederationLocation: "https://eu-west-1.signin.aws.amazon.com/federation",
+    }),
+  };
 };
-const TEST_PROFILE_LOGIN_RESPONSE = JSON.stringify({
-  signInToken: TEST_SIGNIN_TOKEN,
-  signInFederationLocation: "https://eu-west-1.signin.aws.amazon.com/federation",
-});
 
 /*******************************************************************************
  * Tests definition
  *******************************************************************************/
 
-test("Auto-populate with an AWS profile used by the user", async () => {
-  // Given
-  const browser = await setupBrowserWithBackgroundScripts({
-    configuration: { autoPopulateUsedProfiles: true },
-  });
-  // When
-  await browser.webRequest.onBeforeRequest.waitForListener();
-  await browser.webRequest.onBeforeRequest.triggerListener(TEST_PROFILE_LOGIN_REQUEST);
-  // Then
-  const storageContent = await browser.storage.local.get();
-  expect(storageContent.awsProfiles).toEqual({ [TEST_PROFILE.id]: TEST_PROFILE });
-});
-
-test("Open an AWS profile in a new dedicated container", async () => {
-  // Given
-  const browser = await setupBrowserWithBackgroundScripts({
-    configuration: { autoPopulateUsedProfiles: true, openProfileInDedicatedContainer: true },
-  });
-  const activeTabBefore = (await browser.tabs.query({ active: true, currentWindow: true }))[0];
-  // When
-  await browser.webRequest.onBeforeRequest.triggerListener(TEST_PROFILE_LOGIN_REQUEST);
-  await browser.webRequest.sendResponseDataToFilter(TEST_PROFILE_LOGIN_RESPONSE);
-  // Then
-  const activeTab = (await browser.tabs.query({ active: true, currentWindow: true }))[0];
-  expect(activeTab.url).toEqual(TEST_PROFILE_SIGNIN_URL);
-  expect(activeTab.cookieStoreId).toEqual("firefox-container-1");
-  // The new tab should be placed at the same position
-  expect(activeTab.index).toEqual(activeTabBefore.index);
-});
-
-test("Open an AWS profile in an already existing dedicated container", async () => {
-  // Given
-  const browser = await setupBrowserWithBackgroundScripts({
-    configuration: { autoPopulateUsedProfiles: true, openProfileInDedicatedContainer: true },
-  });
-  // When
-  for (const name of ["fakeContainer1", TEST_PROFILE.title, "fakeContainer3"]) {
-    await browser.contextualIdentities.create({ name });
+test.each(PORTAL_STYLES)(
+  "Auto-populate with an AWS profile used by the user (%p style)",
+  async (portalStyle) => {
+    // Given
+    const testData = getTestData(portalStyle);
+    const browser = await setupBrowserWithBackgroundScripts({
+      configuration: { autoPopulateUsedProfiles: true },
+    });
+    // When
+    await browser.webRequest.onBeforeRequest.waitForListener();
+    await browser.webRequest.onBeforeRequest.triggerListener(testData.loginRequest);
+    // Then
+    const storageContent = await browser.storage.local.get();
+    expect(storageContent.awsProfiles).toEqual({ [testData.profile.id]: testData.profile });
   }
-  await browser.webRequest.onBeforeRequest.triggerListener(TEST_PROFILE_LOGIN_REQUEST);
-  await browser.webRequest.sendResponseDataToFilter(TEST_PROFILE_LOGIN_RESPONSE);
-  // Then
-  const tab = await browser.tabs.getCurrent();
-  expect(tab.url).toEqual(TEST_PROFILE_SIGNIN_URL);
-  expect(tab.cookieStoreId).toEqual("firefox-container-2");
-});
+);
+
+test.each(PORTAL_STYLES)(
+  "Open an AWS profile in a new dedicated container (%p style)",
+  async (portalStyle) => {
+    // Given
+    const testData = getTestData(portalStyle);
+    const browser = await setupBrowserWithBackgroundScripts({
+      configuration: { autoPopulateUsedProfiles: true, openProfileInDedicatedContainer: true },
+    });
+    const activeTabBefore = (await browser.tabs.query({ active: true, currentWindow: true }))[0];
+    // When
+    await browser.webRequest.onBeforeRequest.triggerListener(testData.loginRequest);
+    await browser.webRequest.sendResponseDataToFilter(testData.loginResponse);
+    // Then
+    const activeTab = (await browser.tabs.query({ active: true, currentWindow: true }))[0];
+    expect(activeTab.url).toEqual(testData.signinUrl);
+    expect(activeTab.cookieStoreId).toEqual("firefox-container-1");
+    // The new tab should be placed at the same position
+    expect(activeTab.index).toEqual(activeTabBefore.index);
+  }
+);
+
+test.each(PORTAL_STYLES)(
+  "Open an AWS profile in an already existing dedicated container (%p style)",
+  async (portalStyle) => {
+    // Given
+    const testData = getTestData(portalStyle);
+    const browser = await setupBrowserWithBackgroundScripts({
+      configuration: { autoPopulateUsedProfiles: true, openProfileInDedicatedContainer: true },
+    });
+    // When
+    for (const name of ["fakeContainer1", testData.profile.title, "fakeContainer3"]) {
+      await browser.contextualIdentities.create({ name });
+    }
+    await browser.webRequest.onBeforeRequest.triggerListener(testData.loginRequest);
+    await browser.webRequest.sendResponseDataToFilter(testData.loginResponse);
+    // Then
+    const tab = await browser.tabs.getCurrent();
+    expect(tab.url).toEqual(testData.signinUrl);
+    expect(tab.cookieStoreId).toEqual("firefox-container-2");
+  }
+);

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -16,49 +16,81 @@ const waitForCondition = async (condition, timeout = 1000) => {
   }
 };
 
-const buildStorageContentForDomains = (...domains) => {
+const testAccountInfos = {
+  Development: {
+    accountId: "987654321098",
+    profileHashes: {
+      AdministratorAccess: "OTg3NjU0MzIxMDk4X2lucy1hMTIzYmM0NWU2NzhkOTAxX3AtMjNhNGI1YzY3ODlkMGUxZg",
+    },
+  },
+  Production: {
+    accountId: "123456789012",
+    profileHashes: {
+      AdministratorAccess: "MTIzNDU2Nzg5MDEyX2lucy1jMjQ2ZGY4OWUwMTJhYjM1X3AtOTg3NmEyYjM5NDBjNWQ2ZQ",
+    },
+  },
+  Root: {
+    accountId: "234567890123",
+    profileHashes: {
+      AdministratorAccess: "MjM0NTY3ODkwMTIzX2lucy1kMTM1YWM1N2UyNDZiODAzX3AtMTAyOWEzYjQ4NTBjNmQ3ZQ",
+      ReadOnlyAccess: "MjM0NTY3ODkwMTIzX2lucy1kMTM1YWM1N2UyNDZiODAzX3AtNWExYjJjM2Q0ZTVmNmc3aA",
+    },
+  },
+};
+
+const buildProfileUrl = (portalStyle, domain, accountName, profileName) => {
+  const accountId = testAccountInfos[accountName].accountId;
+  const profileHash = testAccountInfos[accountName].profileHashes[profileName];
+  if (portalStyle == "legacy") {
+    return `https://${domain}.awsapps.com/start/#/saml/custom/${accountId}%20%28${accountName}%29/${profileHash}%3D%3D`;
+  } else {
+    return `https://${domain}.awsapps.com/start/#/console?account_id=${accountId}&role_name=${profileName}`;
+  }
+};
+
+const buildStorageContentForDomains = (portalStyle, ...domains) => {
   const colors = ["blue", "turquoise", "green", "yellow", "orange", "red", "pink", "purple"];
   const storageContent = { awsProfiles: {} };
   domains.forEach((domain, index) => {
     const profiles = [
       {
         accountName: "Development",
-        accountId: "987654321098",
+        accountId: testAccountInfos["Development"].accountId,
         color: colors[4 * index],
         name: "AdministratorAccess",
         portalDomain: domain,
         title: "Development - AdministratorAccess",
-        url: `https://${domain}.awsapps.com/start/#/saml/custom/987654321098%20%28Development%29/OTg3NjU0MzIxMDk4X2lucy1hMTIzYmM0NWU2NzhkOTAxX3AtMjNhNGI1YzY3ODlkMGUxZg%3D%3D`,
+        url: buildProfileUrl(portalStyle, domain, "Development", "AdministratorAccess"),
         id: `${domain} - Development - AdministratorAccess`,
       },
       {
         accountName: "Root",
-        accountId: "234567890123",
+        accountId: testAccountInfos["Root"].accountId,
         color: colors[4 * index + 2],
         name: "AdministratorAccess",
         portalDomain: domain,
         title: "Root - AdministratorAccess",
-        url: `https://${domain}.awsapps.com/start/#/saml/custom/234567890123%20%28Root%29/MjM0NTY3ODkwMTIzX2lucy1kMTM1YWM1N2UyNDZiODAzX3AtMTAyOWEzYjQ4NTBjNmQ3ZQ%3D%3D`,
+        url: buildProfileUrl(portalStyle, domain, "Root", "AdministratorAccess"),
         id: `${domain} - Root - AdministratorAccess`,
       },
       {
         accountName: "Root",
-        accountId: "234567890123",
+        accountId: testAccountInfos["Root"].accountId,
         color: colors[4 * index + 3],
         name: "ReadOnlyAccess",
         portalDomain: domain,
         title: "Root - ReadOnlyAccess",
-        url: `https://${domain}.awsapps.com/start/#/saml/custom/234567890123%20%28Root%29/MjM0NTY3ODkwMTIzX2lucy1kMTM1YWM1N2UyNDZiODAzX3AtNWExYjJjM2Q0ZTVmNmc3aA%3D%3D`,
+        url: buildProfileUrl(portalStyle, domain, "Root", "ReadOnlyAccess"),
         id: `${domain} - Root - ReadOnlyAccess`,
       },
       {
         accountName: "Production",
-        accountId: "123456789012",
+        accountId: testAccountInfos["Production"].accountId,
         color: colors[4 * index + 1],
         name: "AdministratorAccess",
         portalDomain: domain,
         title: "Production - AdministratorAccess",
-        url: `https://${domain}.awsapps.com/start/#/saml/custom/123456789012%20%28Production%29/MTIzNDU2Nzg5MDEyX2lucy1jMjQ2ZGY4OWUwMTJhYjM1X3AtOTg3NmEyYjM5NDBjNWQ2ZQ%3D%3D`,
+        url: buildProfileUrl(portalStyle, domain, "Production", "AdministratorAccess"),
         id: `${domain} - Production - AdministratorAccess`,
       },
     ];

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -57,45 +57,42 @@ const buildStorageContentForDomains = (portalStyle, ...domains) => {
         accountName: "Development",
         accountId: testAccountInfos["Development"].accountId,
         color: colors[4 * index],
-        name: "AdministratorAccess",
+        profileName: "AdministratorAccess",
         portalDomain: domain,
-        title: "Development - AdministratorAccess",
         url: buildProfileUrl(portalStyle, domain, "Development", "AdministratorAccess"),
-        id: `${domain} - Development - AdministratorAccess`,
+        favorite: false,
       },
       {
         accountName: "Root",
         accountId: testAccountInfos["Root"].accountId,
         color: colors[4 * index + 2],
-        name: "AdministratorAccess",
+        profileName: "AdministratorAccess",
         portalDomain: domain,
-        title: "Root - AdministratorAccess",
         url: buildProfileUrl(portalStyle, domain, "Root", "AdministratorAccess"),
-        id: `${domain} - Root - AdministratorAccess`,
+        favorite: false,
       },
       {
         accountName: "Root",
         accountId: testAccountInfos["Root"].accountId,
         color: colors[4 * index + 3],
-        name: "ReadOnlyAccess",
+        profileName: "ReadOnlyAccess",
         portalDomain: domain,
-        title: "Root - ReadOnlyAccess",
         url: buildProfileUrl(portalStyle, domain, "Root", "ReadOnlyAccess"),
-        id: `${domain} - Root - ReadOnlyAccess`,
+        favorite: false,
       },
       {
         accountName: "Production",
         accountId: testAccountInfos["Production"].accountId,
         color: colors[4 * index + 1],
-        name: "AdministratorAccess",
+        profileName: "AdministratorAccess",
         portalDomain: domain,
-        title: "Production - AdministratorAccess",
         url: buildProfileUrl(portalStyle, domain, "Production", "AdministratorAccess"),
-        id: `${domain} - Production - AdministratorAccess`,
+        favorite: false,
       },
     ];
     profiles.forEach((profile) => {
-      storageContent.awsProfiles[profile.id] = profile;
+      const profileId = `${profile.portalDomain} - ${profile.accountId} - ${profile.profileName}`;
+      storageContent.awsProfiles[profileId] = profile;
     });
   });
 

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -11,6 +11,8 @@ const {
  * Constants
  *******************************************************************************/
 
+const PORTAL_STYLES = ["legacy", "new"];
+
 const SRC_FOLDER = path.join(__dirname, "..", "src");
 const POPUP_HTML_FILE = path.join(SRC_FOLDER, "popup", "popup.html");
 
@@ -28,9 +30,9 @@ const searchboxFocused = (page) => async () => {
  * Tests definition
  *******************************************************************************/
 
-test("Load and display roles from storage", async () => {
+test.each(PORTAL_STYLES)("Load and display roles from storage (%p style)", async (portalStyle) => {
   // Given
-  const storageContent = buildStorageContentForDomains("mysso");
+  const storageContent = buildStorageContentForDomains(portalStyle, "mysso");
   const favoriteProfile = Object.values(storageContent.awsProfiles)[1];
   favoriteProfile.favorite = true;
   const browserStorage = mockBrowserStorage(storageContent);

--- a/tests/popup.test.js
+++ b/tests/popup.test.js
@@ -53,7 +53,7 @@ test.each(PORTAL_STYLES)("Load and display roles from storage (%p style)", async
     "Root - AdministratorAccess",
     "Root - ReadOnlyAccess",
   ]);
-  expect(favoriteProfileDiv.textContent).toEqual(favoriteProfile.title);
+  expect(favoriteProfileDiv.textContent).toEqual("Root - AdministratorAccess");
 });
 
 test("Display instructions when no profiles exist", async () => {

--- a/tests/profiles_info_loader.test.js
+++ b/tests/profiles_info_loader.test.js
@@ -167,7 +167,6 @@ test.each(PORTAL_STYLES)(
   async (portalStyle) => {
     // Given
     const storageContent = buildStorageContentForDomains(portalStyle, "mysso");
-    const awsProfiles = storageContent.awsProfiles;
     // We set one element to be favorite and expect its state to be preserved
     const favoriteProfile = Object.values(storageContent.awsProfiles)[1];
     favoriteProfile.favorite = true;
@@ -175,9 +174,12 @@ test.each(PORTAL_STYLES)(
     const expectedProfilesCount = Object.keys(expectedContent.awsProfiles).length;
 
     // We add a new account not present in the portal and expect to be removed on update
-    awsProfiles.ToBeRemoved = Object.assign({}, Object.values(awsProfiles)[0], {
-      id: "ToBeRemoved",
-    });
+    storageContent.awsProfiles["mysso - 777777777777 - ToBeRemoved"] = {
+      portalDomain: "mysso",
+      accountId: "777777777777",
+      accountName: "fakeAccount",
+      profileName: "ToBeRemoved",
+    };
 
     const browserStorage = mockBrowserStorage(storageContent);
     const awsPortalPage = await createFakeAwsPortalPage(`aws_portal.${portalStyle}.mysso.html`, {

--- a/tests/test_files/aws_portal.legacy.anothersso.html
+++ b/tests/test_files/aws_portal.legacy.anothersso.html
@@ -27,7 +27,7 @@
                   <img _ngcontent-c2="" />
                 </a>
                 <div _ngcontent-c2="" class="service-links">
-                  <span _ngcontent-c2="" class="user-display-name">Yann</span>
+                  <span _ngcontent-c2="" class="user-display-name">John</span>
                   <div _ngcontent-c2="" class="divider"></div>
 
                   <a
@@ -86,7 +86,7 @@
                           "
                         ></div>
                         <div _ngcontent-c14="" class="title" title="AWS Account">
-                          AWS Account (13)
+                          AWS Account (4)
                         </div>
                       </portal-application>
 

--- a/tests/test_files/aws_portal.legacy.mysso.expanded_sections.html
+++ b/tests/test_files/aws_portal.legacy.mysso.expanded_sections.html
@@ -27,7 +27,7 @@
                   <img _ngcontent-c2="" />
                 </a>
                 <div _ngcontent-c2="" class="service-links">
-                  <span _ngcontent-c2="" class="user-display-name">Yann</span>
+                  <span _ngcontent-c2="" class="user-display-name">John</span>
                   <div _ngcontent-c2="" class="divider"></div>
 
                   <a

--- a/tests/test_files/aws_portal.legacy.mysso.folded_sections.html
+++ b/tests/test_files/aws_portal.legacy.mysso.folded_sections.html
@@ -27,7 +27,7 @@
                   <img _ngcontent-c2="" />
                 </a>
                 <div _ngcontent-c2="" class="service-links">
-                  <span _ngcontent-c2="" class="user-display-name">Yann</span>
+                  <span _ngcontent-c2="" class="user-display-name">John</span>
                   <div _ngcontent-c2="" class="divider"></div>
 
                   <a
@@ -91,7 +91,7 @@
                       </portal-application>
 
                       <div _ngcontent-c12="" class="empty-application"></div>
-                      <sso-expander
+                      <sso-expander-hidden
                         _ngcontent-c12=""
                         _nghost-c15=""
                         class="ng-tns-c15-3 ng-trigger ng-trigger-expand"
@@ -152,7 +152,7 @@
                                     style="transform: rotate(270deg)"
                                   />
                                 </div>
-                                <sso-expander
+                                <sso-expander-hidden
                                   _ngcontent-c17=""
                                   _nghost-c15=""
                                   class="ng-tns-c15-18 ng-tns-c17-5 ng-trigger ng-trigger-expand"
@@ -211,8 +211,8 @@
                                         </span>
                                       </portal-profile>
                                     </div>
-                                  </portal-profile-list></sso-expander
-                                >
+                                  </portal-profile-list>
+                                </sso-expander-hidden>
                               </div>
                             </portal-instance>
                           </div>
@@ -265,7 +265,7 @@
                                     style="transform: rotate(270deg)"
                                   />
                                 </div>
-                                <sso-expander
+                                <sso-expander-hidden
                                   _ngcontent-c17=""
                                   _nghost-c15=""
                                   class="ng-tns-c15-20 ng-tns-c17-6 ng-trigger ng-trigger-expand"
@@ -324,7 +324,7 @@
                                       </portal-profile>
                                     </div>
                                   </portal-profile-list>
-                                </sso-expander>
+                                </sso-expander-hidden>
                               </div>
                             </portal-instance>
                           </div>
@@ -481,10 +481,9 @@
                               </div>
                             </portal-instance>
                           </div>
-
                           <div _ngcontent-c16="" class="triangle col-1-of-4"></div>
                         </portal-instance-list>
-                      </sso-expander>
+                      </sso-expander-hidden>
                     </portal-application-list>
                   </div>
                 </portal-dashboard>

--- a/tests/test_files/aws_portal.legacy.mysso.html
+++ b/tests/test_files/aws_portal.legacy.mysso.html
@@ -27,7 +27,7 @@
                   <img _ngcontent-c2="" />
                 </a>
                 <div _ngcontent-c2="" class="service-links">
-                  <span _ngcontent-c2="" class="user-display-name">Yann</span>
+                  <span _ngcontent-c2="" class="user-display-name">John</span>
                   <div _ngcontent-c2="" class="divider"></div>
 
                   <a
@@ -91,7 +91,7 @@
                       </portal-application>
 
                       <div _ngcontent-c12="" class="empty-application"></div>
-                      <sso-expander-hidden
+                      <sso-expander
                         _ngcontent-c12=""
                         _nghost-c15=""
                         class="ng-tns-c15-3 ng-trigger ng-trigger-expand"
@@ -152,7 +152,7 @@
                                     style="transform: rotate(270deg)"
                                   />
                                 </div>
-                                <sso-expander-hidden
+                                <sso-expander
                                   _ngcontent-c17=""
                                   _nghost-c15=""
                                   class="ng-tns-c15-18 ng-tns-c17-5 ng-trigger ng-trigger-expand"
@@ -211,8 +211,8 @@
                                         </span>
                                       </portal-profile>
                                     </div>
-                                  </portal-profile-list>
-                                </sso-expander-hidden>
+                                  </portal-profile-list></sso-expander
+                                >
                               </div>
                             </portal-instance>
                           </div>
@@ -265,7 +265,7 @@
                                     style="transform: rotate(270deg)"
                                   />
                                 </div>
-                                <sso-expander-hidden
+                                <sso-expander
                                   _ngcontent-c17=""
                                   _nghost-c15=""
                                   class="ng-tns-c15-20 ng-tns-c17-6 ng-trigger ng-trigger-expand"
@@ -324,7 +324,7 @@
                                       </portal-profile>
                                     </div>
                                   </portal-profile-list>
-                                </sso-expander-hidden>
+                                </sso-expander>
                               </div>
                             </portal-instance>
                           </div>
@@ -481,9 +481,10 @@
                               </div>
                             </portal-instance>
                           </div>
+
                           <div _ngcontent-c16="" class="triangle col-1-of-4"></div>
                         </portal-instance-list>
-                      </sso-expander-hidden>
+                      </sso-expander>
                     </portal-application-list>
                   </div>
                 </portal-dashboard>

--- a/tests/test_files/aws_portal.new.anothersso.html
+++ b/tests/test_files/aws_portal.new.anothersso.html
@@ -1,0 +1,1299 @@
+<html lang="en" class="osfqxsm idc0_350">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; object-src 'none'; base-uri 'self'; img-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://static.global.sso.amazonaws.com/ data: 'self'; script-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.cdn.uis.awsstatic.com/ https://*.cdn.console.awsstatic.com/ https://*.shortbread.aws.dev/ 'self'; style-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.shortbread.aws.dev/ 'self' 'unsafe-inline'; font-src https://assets.sso-portal.eu-west-1.amazonaws.com/ data: 'self'; connect-src https://portal.sso.eu-west-1.amazonaws.com https://oidc.eu-west-1.amazonaws.com https://up.sso.eu-west-1.amazonaws.com https://log.sso-portal.eu-west-1.amazonaws.com https://*.analytics.console.aws.a2z.com https://*.feedback.console.aws.dev https://*.shortbread.aws.dev/ 'self';"
+    />
+    <title>AWS access portal</title>
+    <meta name="version" content="2" />
+  </head>
+
+  <body data-new-gr-c-s-check-loaded="8.911.0" data-gr-ext-installed="">
+    <div id="awsccc-sb-ux-c">
+      <div id="awsccc-sb-a" class="">
+        <div data-id="awsccc-cb" style="display: none">
+          <div
+            id="awsccc-cb-c"
+            data-id="awsccc-cb-tabstart"
+            class="awsccc-tab-helper"
+            tabindex="-1"
+          >
+            <div id="awsccc-cb-content">
+              <div id="awsccc-cb-text-section">
+                <h2 id="awsccc-cb-title">Select your cookie preferences</h2>
+                <p id="awsccc-cb-text">
+                  <span
+                    >We use essential cookies and similar tools that are necessary to provide our
+                    site and services. We use performance cookies to collect anonymous statistics so
+                    we can understand how customers use our site and make improvements. Essential
+                    cookies cannot be deactivated, but you can click “Customize cookies” to decline
+                    performance cookies. <br /><br />
+                    If you agree, AWS and approved third parties will also use cookies to provide
+                    useful site features, remember your preferences, and display relevant content,
+                    including relevant advertising. To continue without accepting these cookies,
+                    click “Continue without accepting.” To make more detailed choices or learn more,
+                    click “Customize cookies.”</span
+                  >
+                </p>
+              </div>
+              <div id="awsccc-cb-actions">
+                <div id="awsccc-cb-buttons">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-accept"
+                    type="submit"
+                    aria-label="Accept all cookies"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Accept all cookies</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-continue"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Continue without accepting</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-customize"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Customize cookies</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div data-id="awsccc-cs" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-cs-container"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Customize cookie preferences"
+            data-awsccc-modal-toggle="true"
+            data-id="awsccc-cs-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-cs-container-inner">
+              <div id="awsccc-cs-content">
+                <div id="awsccc-cs-header">
+                  <div id="awsccc-cs-title">
+                    <h2>Customize cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-cs-modalBody">
+                  <div id="awsccc-cs-i-container">
+                    <span
+                      >We use cookies and similar tools (collectively, "cookies") for the following
+                      purposes.</span
+                    >
+                  </div>
+                  <div data-category="essential" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Essential</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Essential cookies are necessary to provide our site and services and cannot
+                        be deactivated. They are usually set in response to your actions on the
+                        site, such as setting your privacy preferences, signing in, or filling in
+                        forms.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action"></div>
+                  </div>
+                  <div data-category="performance" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Performance</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Performance cookies provide anonymous statistics about how customers
+                        navigate our site so we can improve site experience and performance.
+                        Approved third parties may perform analytics on our behalf, but they cannot
+                        use the data for their own purposes.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-performance-container"
+                          >
+                            <label data-id="awsccc-u-cb-performance-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-performance"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow performance category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="functional" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Functional</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Functional cookies help us provide useful site features, remember your
+                        preferences, and display relevant content. Approved third parties may set
+                        these cookies to provide certain site features. If you do not allow these
+                        cookies, then some or all of these services may not function properly.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-functional-container"
+                          >
+                            <label data-id="awsccc-u-cb-functional-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-functional"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow functional category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="advertising" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Advertising</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Advertising cookies may be set through our site by us or our advertising
+                        partners and help us deliver relevant marketing content. If you do not allow
+                        these cookies, you will experience less relevant advertising.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-advertising-container"
+                          >
+                            <label data-id="awsccc-u-cb-advertising-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-advertising"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow advertising category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="awsccc-cs-l-container">
+                    <p>
+                      <span
+                        >Blocking some types of cookies may impact your experience of our sites. You
+                        may review and change your choices at any time by clicking Cookie
+                        preferences in the footer of this site. We and selected third-parties use
+                        cookies or similar technologies as specified in the&nbsp;<a
+                          data-id="awsccc-cs-f-notice"
+                          href="https://aws.amazon.com/legal/cookies/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          ><span
+                            >AWS Cookie Notice<span
+                              aria-label="Opens in a new Window"
+                              role="img"
+                              class="awsccc-u-i-open-c"
+                              ><svg
+                                class="awsccc-u-i-open"
+                                viewBox="0 0 16 16"
+                                focusable="false"
+                                aria-hidden="true"
+                              >
+                                <path class="awsccc-stroke-linecap-square" d="M10 2h4v4"></path>
+                                <path d="M6 10l8-8"></path>
+                                <path
+                                  class="awsccc-stroke-linejoin-round"
+                                  d="M14 9.048V14H2V2h5"
+                                ></path></svg></span></span></a
+                        >.</span
+                      >
+                    </p>
+                  </div>
+                </div>
+                <div id="awsccc-cs-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-cancel"
+                    type="submit"
+                    aria-label="Cancel customizing cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Cancel</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-save"
+                    type="submit"
+                    aria-label="Save customized cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Save preferences</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-cs-modalOverlay"></div>
+          <div data-id="awsccc-cs-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+        <div data-id="awsccc-em-modal" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-em-container"
+            role="dialog"
+            aria-modal="true"
+            data-awsccc-emm-modal-toggle="true"
+            data-id="awsccc-em-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-em-container-inner">
+              <div id="awsccc-em-content">
+                <div id="awsccc-em-header">
+                  <div id="awsccc-em-title">
+                    <h2>Unable to save cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-em-modalBody">
+                  <p id="awsccc-emm-paragraph">
+                    <span
+                      >We will only store essential cookies at this time, because we were unable to
+                      save your cookie preferences.<br /><br />If you want to change your cookie
+                      preferences, try again later using the link in the AWS console footer, or
+                      contact support if the problem persists.</span
+                    >
+                  </p>
+                </div>
+                <div id="awsccc-em-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-em-btn-dismiss"
+                    type="submit"
+                    aria-label="Dismiss error message modal"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Dismiss</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-em-modalOverlay"></div>
+          <div data-id="awsccc-em-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+      </div>
+    </div>
+    <div style="position: absolute; left: -999999px; top: -99999px">
+      <span id="u2f_container"></span> <span id="ap_tokenCode"></span> <span id="mfa_form"></span>
+      <span id="mfa_container"></span>
+    </div>
+    <div id="root">
+      <div
+        id="header"
+        class="zBdDUx8FRw_DiWiJVBtE"
+        data-analytics="nav-header"
+        data-analytics-type="eventContext"
+      >
+        <div>
+          <div class="awsui-context-top-navigation">
+            <header class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_narrow_k5dlb_qkzrh_162">
+              <div class="awsui_padding-box_k5dlb_qkzrh_152">
+                <div class="awsui_identity_k5dlb_qkzrh_189">
+                  <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+                    ><img
+                      role="img"
+                      src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                      alt="AWS Access Portal (AWS Smile Icon)"
+                      class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                      class="awsui_title_k5dlb_qkzrh_228"
+                    ></span
+                  ></a>
+                </div>
+                <div class="awsui_utilities_k5dlb_qkzrh_259">
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="0"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self1-1711662765899-5709"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="John"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link0-1711662765899-3918"
+                        role="button"
+                        tabindex="0"
+                        ><span>John</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="1"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self4-1711662765899-2524"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="MFA devices"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link3-1711662765899-896"
+                        href="#/devices"
+                        ><span>MFA devices</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="2"
+                    data-utility-hide="false"
+                  >
+                    <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                      ><a
+                        id="link-self7-1711662765899-9538"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="Sign out"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link6-1711662765899-516"
+                        href="#/signout"
+                        ><span>Sign out</span></a
+                      ></span
+                    >
+                  </div>
+                </div>
+              </div>
+            </header>
+          </div>
+        </div>
+      </div>
+      <div style="">
+        <div
+          class="awsui_root_lm6vo_ttnir_133 awsui_root_1fj9k_1uvk8_5"
+          style="min-height: calc(0px + 100vh)"
+        >
+          <div class="awsui_layout_lm6vo_ttnir_145">
+            <main class="awsui_layout-main_lm6vo_ttnir_155">
+              <div>
+                <div
+                  class="awsui_content-wrapper_zycdx_1sc8d_103 awsui_content-wrapper-mobile_zycdx_1sc8d_107"
+                >
+                  <div
+                    class="awsui_content-wrapper_lm6vo_ttnir_179 awsui_content-extra-top-padding_lm6vo_ttnir_187 awsui_content_1fj9k_1uvk8_21"
+                  >
+                    <div id="content-wrapper" class="D8xb6dfGpkfz6Jls9_GX">
+                      <div class="t1K3zqLzYokQtjgU2P5t" style="">
+                        <div
+                          class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_m-bottom-s_18wu0_1qbfe_879 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                        >
+                          <div
+                            class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h1_2qdw9_gej2d_150 awsui_root-no-actions_2qdw9_gej2d_138"
+                          >
+                            <div
+                              class="awsui_main_2qdw9_gej2d_160 awsui_main-variant-h1_2qdw9_gej2d_176"
+                            >
+                              <div
+                                class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h1_2qdw9_gej2d_221"
+                              >
+                                <h1
+                                  class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h1_2qdw9_gej2d_307"
+                                >
+                                  <span
+                                    class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h1_2qdw9_gej2d_330"
+                                    id="heading46-1711662766262-5985"
+                                    >AWS access portal</span
+                                  >
+                                </h1>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="awsui_root_14rmt_1ojt0_389 awsui_tabs_14rmt_1ojt0_198">
+                          <div
+                            class="awsui_tabs-header_14rmt_1ojt0_198 awsui_tabs-header-with-divider_14rmt_1ojt0_385"
+                          >
+                            <ul role="tablist" class="awsui_tabs-header-list_14rmt_1ojt0_206">
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273 awsui_tabs-tab-active_14rmt_1ojt0_378"
+                                  role="tab"
+                                  aria-selected="true"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                                  data-testid="accounts"
+                                  id="awsui-tabs-47-1711662766263-6233-accounts"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Accounts</span></span
+                                  >
+                                </button>
+                              </li>
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273"
+                                  role="tab"
+                                  aria-selected="false"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-applications-panel"
+                                  data-testid="applications"
+                                  id="awsui-tabs-47-1711662766263-6233-applications"
+                                  tabindex="-1"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Applications</span></span
+                                  >
+                                </button>
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            class="awsui_tabs-content-wrapper_14rmt_1ojt0_454 awsui_with-paddings_14rmt_1ojt0_454"
+                          >
+                            <div
+                              class="awsui_tabs-content_14rmt_1ojt0_430 awsui_tabs-content-active_14rmt_1ojt0_440"
+                              role="tabpanel"
+                              id="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                              tabindex="0"
+                              aria-labelledby="awsui-tabs-47-1711662766263-6233-accounts"
+                            >
+                              <div
+                                class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-s_18582_uh010_158"
+                              >
+                                <div class="awsui_child_18582_uh010_103"></div>
+                                <div class="awsui_child_18582_uh010_103">
+                                  <div
+                                    class="awsui_root_14iqq_1w23c_103 awsui_variant-default_14iqq_1w23c_147"
+                                  >
+                                    <div
+                                      id="49-1711662766293-5856"
+                                      class="awsui_content-wrapper_14iqq_1w23c_222"
+                                    >
+                                      <div
+                                        class="awsui_header_14iqq_1w23c_261 awsui_with-paddings_14iqq_1w23c_301"
+                                      >
+                                        <div
+                                          data-analytics="accounts-list-header"
+                                          data-analytics-type="eventContext"
+                                          class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xs_18582_uh010_155"
+                                        >
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div
+                                              class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h2_2qdw9_gej2d_141 awsui_root-no-actions_2qdw9_gej2d_138"
+                                            >
+                                              <div class="awsui_main_2qdw9_gej2d_160">
+                                                <div
+                                                  class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h2_2qdw9_gej2d_228"
+                                                >
+                                                  <h2
+                                                    class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h2_2qdw9_gej2d_312"
+                                                  >
+                                                    <span
+                                                      data-analytics-funnel-key="substep-name"
+                                                      class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h2_2qdw9_gej2d_338"
+                                                      id="heading50-1711662766293-7070"
+                                                      ><span>AWS accounts (3)</span></span
+                                                    >
+                                                  </h2>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div class="awsui_grid_14yj0_63b5v_99">
+                                              <div
+                                                class="awsui_grid-column_14yj0_63b5v_143 awsui_colspan-12_14yj0_63b5v_264"
+                                              >
+                                                <div
+                                                  class="awsui_restore-pointer-events_14yj0_63b5v_314"
+                                                >
+                                                  <div class="BsOvt3K1aqEszThhXAnd">
+                                                    <div
+                                                      data-testid="list-header-text-filter"
+                                                      data-analytics="list-header-text-filter"
+                                                      data-analytics-type="eventDetail"
+                                                      class="awsui_root_1sdq3_1cqzf_99"
+                                                    >
+                                                      <div
+                                                        class="awsui_input_1sdq3_1cqzf_137 awsui_input-container_2rhyz_qevde_262"
+                                                      >
+                                                        <span
+                                                          class="awsui_input-icon-left_2rhyz_qevde_267"
+                                                          ><span
+                                                            class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-subtle_h11ix_obmua_239"
+                                                            ><svg
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                              viewBox="0 0 16 16"
+                                                              focusable="false"
+                                                              aria-hidden="true"
+                                                            >
+                                                              <circle cx="7" cy="7" r="5"></circle>
+                                                              <path
+                                                                d="m15 15-4.5-4.5"
+                                                              ></path></svg></span></span
+                                                        ><input
+                                                          aria-label="Filter accounts by name, ID, or email address"
+                                                          placeholder="Filter accounts by name, ID, or email address"
+                                                          class="awsui_input_2rhyz_qevde_103 awsui_input-type-search_2rhyz_qevde_236 awsui_input-has-icon-left_2rhyz_qevde_231"
+                                                          autocomplete="off"
+                                                          type="search"
+                                                          value=""
+                                                        />
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div class="awsui_content_14iqq_1w23c_222">
+                                        <div data-testid="account-list">
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Development</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      987654321098 | aws-development@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=987654321098&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Production</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      123456789012 | aws-production@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=123456789012&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Root</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      234567890123 | aws-root@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=ReadOnlyAccess"
+                                                    >ReadOnlyAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="awsui_tabs-content_14rmt_1ojt0_430"
+                            role="tabpanel"
+                            id="awsui-tabs-47-1711662766263-6233-applications-panel"
+                            tabindex="0"
+                            aria-labelledby="awsui-tabs-47-1711662766263-6233-applications"
+                          ></div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
+      </div>
+      <div
+        id="footer"
+        class="A3g9fuQWIhSmqmpMV_H8"
+        data-analytics="nav-footer"
+        data-analytics-type="eventContext"
+      >
+        <div class="NKvyJBFp1PzWTL6f_OWR">
+          <a
+            id="link-self10-1711662765900-7179"
+            data-testid="feedback-link"
+            data-analytics="footer-link-feedback"
+            data-analytics-type="eventDetail"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link9-1711662765900-5024"
+            role="button"
+            tabindex="0"
+            >Feedback</a
+          >
+        </div>
+        <div class="AwKnBv8vVIbohRP_1Nex">
+          <div
+            class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-inherit_18wu0_1qbfe_360 awsui_font-size-body-s_18wu0_1qbfe_363 awsui_font-weight-default_18wu0_1qbfe_275"
+          >
+            ©2024, Amazon Web Services, Inc. or its affiliates. All rights reserved.
+          </div>
+        </div>
+        <div class="NKvyJBFp1PzWTL6f_OWR QDppO6mR7sx8I2Tm0f_n">
+          <a
+            id="link-self13-1711662765900-718"
+            data-analytics="footer-link-privacy"
+            data-analytics-type="eventDetail"
+            data-testid="privacy-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link12-1711662765900-8218"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/privacy/"
+            >Privacy</a
+          ><a
+            id="link-self16-1711662765900-8033"
+            data-analytics="footer-link-terms"
+            data-analytics-type="eventDetail"
+            data-testid="terms-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link15-1711662765900-8357"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/terms/"
+            >Terms</a
+          ><a
+            id="link-self19-1711662765900-6302"
+            data-analytics="footer-link-cookie-preferences"
+            data-analytics-type="eventDetail"
+            data-testid="cookie-preferences-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link18-1711662765900-5299"
+            role="button"
+            tabindex="0"
+            >Cookie Preferences</a
+          >
+        </div>
+      </div>
+    </div>
+    <div
+      id="awsc-aperture-widget-tracker-container"
+      data-analytics-widget-id="awsc-aperture-widget-modal"
+    >
+      <div id="awsc-aperture-widget-modal-container"></div>
+    </div>
+    <div>
+      <div
+        aria-hidden="true"
+        class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_virtual_k5dlb_qkzrh_173 awsui_hidden_k5dlb_qkzrh_177 awsui_narrow_k5dlb_qkzrh_162"
+      >
+        <div class="awsui_padding-box_k5dlb_qkzrh_152">
+          <div class="awsui_identity_k5dlb_qkzrh_189">
+            <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+              ><img
+                role="img"
+                src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                alt="AWS Access Portal (AWS Smile Icon)"
+                class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                class="awsui_title_k5dlb_qkzrh_228"
+              ></span
+            ></a>
+          </div>
+          <div class="awsui_utilities_k5dlb_qkzrh_259">
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="search"
+            >
+              <span
+                ><a
+                  id="link-self22-1711662765904-5989"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Search"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link21-1711662765904-9226"
+                  role="button"
+                  tabindex="0"
+                  ><span
+                    class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                    ><svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 16 16"
+                      focusable="false"
+                      aria-hidden="true"
+                    >
+                      <circle cx="7" cy="7" r="5"></circle>
+                      <path d="m15 15-4.5-4.5"></path></svg></span></a
+              ></span>
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self25-1711662765905-1512"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link24-1711662765905-5182"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self28-1711662765905-9207"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link27-1711662765905-5996"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="false"
+            >
+              <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                ><a
+                  id="link-self31-1711662765905-9830"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link30-1711662765905-9861"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self34-1711662765905-1739"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link33-1711662765905-8834"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self37-1711662765905-9176"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link36-1711662765905-6389"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self40-1711662765905-8633"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link39-1711662765905-4901"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-menu-dropdown_k5dlb_qkzrh_296 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="menu-trigger"
+            >
+              <button
+                type="button"
+                class="awsui_button_m5h9f_r0dm2_99 awsui_offset-right-l_m5h9f_r0dm2_168"
+                aria-expanded="false"
+                aria-haspopup="true"
+              >
+                <span class="awsui_text_m5h9f_r0dm2_196">More</span
+                ><span
+                  class="awsui_rotate-down_sne0l_lqyym_137 awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                  ><svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    focusable="false"
+                    aria-hidden="true"
+                  >
+                    <path class="filled stroke-linejoin-round" d="M4 5h8l-4 6-4-6z"></path></svg
+                ></span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/test_files/aws_portal.new.mysso.expanded_sections.html
+++ b/tests/test_files/aws_portal.new.mysso.expanded_sections.html
@@ -1,0 +1,1299 @@
+<html lang="en" class="osfqxsm idc0_350">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; object-src 'none'; base-uri 'self'; img-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://static.global.sso.amazonaws.com/ data: 'self'; script-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.cdn.uis.awsstatic.com/ https://*.cdn.console.awsstatic.com/ https://*.shortbread.aws.dev/ 'self'; style-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.shortbread.aws.dev/ 'self' 'unsafe-inline'; font-src https://assets.sso-portal.eu-west-1.amazonaws.com/ data: 'self'; connect-src https://portal.sso.eu-west-1.amazonaws.com https://oidc.eu-west-1.amazonaws.com https://up.sso.eu-west-1.amazonaws.com https://log.sso-portal.eu-west-1.amazonaws.com https://*.analytics.console.aws.a2z.com https://*.feedback.console.aws.dev https://*.shortbread.aws.dev/ 'self';"
+    />
+    <title>AWS access portal</title>
+    <meta name="version" content="2" />
+  </head>
+
+  <body data-new-gr-c-s-check-loaded="8.911.0" data-gr-ext-installed="">
+    <div id="awsccc-sb-ux-c">
+      <div id="awsccc-sb-a" class="">
+        <div data-id="awsccc-cb" style="display: none">
+          <div
+            id="awsccc-cb-c"
+            data-id="awsccc-cb-tabstart"
+            class="awsccc-tab-helper"
+            tabindex="-1"
+          >
+            <div id="awsccc-cb-content">
+              <div id="awsccc-cb-text-section">
+                <h2 id="awsccc-cb-title">Select your cookie preferences</h2>
+                <p id="awsccc-cb-text">
+                  <span
+                    >We use essential cookies and similar tools that are necessary to provide our
+                    site and services. We use performance cookies to collect anonymous statistics so
+                    we can understand how customers use our site and make improvements. Essential
+                    cookies cannot be deactivated, but you can click “Customize cookies” to decline
+                    performance cookies. <br /><br />
+                    If you agree, AWS and approved third parties will also use cookies to provide
+                    useful site features, remember your preferences, and display relevant content,
+                    including relevant advertising. To continue without accepting these cookies,
+                    click “Continue without accepting.” To make more detailed choices or learn more,
+                    click “Customize cookies.”</span
+                  >
+                </p>
+              </div>
+              <div id="awsccc-cb-actions">
+                <div id="awsccc-cb-buttons">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-accept"
+                    type="submit"
+                    aria-label="Accept all cookies"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Accept all cookies</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-continue"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Continue without accepting</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-customize"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Customize cookies</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div data-id="awsccc-cs" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-cs-container"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Customize cookie preferences"
+            data-awsccc-modal-toggle="true"
+            data-id="awsccc-cs-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-cs-container-inner">
+              <div id="awsccc-cs-content">
+                <div id="awsccc-cs-header">
+                  <div id="awsccc-cs-title">
+                    <h2>Customize cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-cs-modalBody">
+                  <div id="awsccc-cs-i-container">
+                    <span
+                      >We use cookies and similar tools (collectively, "cookies") for the following
+                      purposes.</span
+                    >
+                  </div>
+                  <div data-category="essential" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Essential</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Essential cookies are necessary to provide our site and services and cannot
+                        be deactivated. They are usually set in response to your actions on the
+                        site, such as setting your privacy preferences, signing in, or filling in
+                        forms.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action"></div>
+                  </div>
+                  <div data-category="performance" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Performance</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Performance cookies provide anonymous statistics about how customers
+                        navigate our site so we can improve site experience and performance.
+                        Approved third parties may perform analytics on our behalf, but they cannot
+                        use the data for their own purposes.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-performance-container"
+                          >
+                            <label data-id="awsccc-u-cb-performance-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-performance"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow performance category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="functional" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Functional</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Functional cookies help us provide useful site features, remember your
+                        preferences, and display relevant content. Approved third parties may set
+                        these cookies to provide certain site features. If you do not allow these
+                        cookies, then some or all of these services may not function properly.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-functional-container"
+                          >
+                            <label data-id="awsccc-u-cb-functional-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-functional"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow functional category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="advertising" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Advertising</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Advertising cookies may be set through our site by us or our advertising
+                        partners and help us deliver relevant marketing content. If you do not allow
+                        these cookies, you will experience less relevant advertising.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-advertising-container"
+                          >
+                            <label data-id="awsccc-u-cb-advertising-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-advertising"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow advertising category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="awsccc-cs-l-container">
+                    <p>
+                      <span
+                        >Blocking some types of cookies may impact your experience of our sites. You
+                        may review and change your choices at any time by clicking Cookie
+                        preferences in the footer of this site. We and selected third-parties use
+                        cookies or similar technologies as specified in the&nbsp;<a
+                          data-id="awsccc-cs-f-notice"
+                          href="https://aws.amazon.com/legal/cookies/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          ><span
+                            >AWS Cookie Notice<span
+                              aria-label="Opens in a new Window"
+                              role="img"
+                              class="awsccc-u-i-open-c"
+                              ><svg
+                                class="awsccc-u-i-open"
+                                viewBox="0 0 16 16"
+                                focusable="false"
+                                aria-hidden="true"
+                              >
+                                <path class="awsccc-stroke-linecap-square" d="M10 2h4v4"></path>
+                                <path d="M6 10l8-8"></path>
+                                <path
+                                  class="awsccc-stroke-linejoin-round"
+                                  d="M14 9.048V14H2V2h5"
+                                ></path></svg></span></span></a
+                        >.</span
+                      >
+                    </p>
+                  </div>
+                </div>
+                <div id="awsccc-cs-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-cancel"
+                    type="submit"
+                    aria-label="Cancel customizing cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Cancel</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-save"
+                    type="submit"
+                    aria-label="Save customized cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Save preferences</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-cs-modalOverlay"></div>
+          <div data-id="awsccc-cs-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+        <div data-id="awsccc-em-modal" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-em-container"
+            role="dialog"
+            aria-modal="true"
+            data-awsccc-emm-modal-toggle="true"
+            data-id="awsccc-em-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-em-container-inner">
+              <div id="awsccc-em-content">
+                <div id="awsccc-em-header">
+                  <div id="awsccc-em-title">
+                    <h2>Unable to save cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-em-modalBody">
+                  <p id="awsccc-emm-paragraph">
+                    <span
+                      >We will only store essential cookies at this time, because we were unable to
+                      save your cookie preferences.<br /><br />If you want to change your cookie
+                      preferences, try again later using the link in the AWS console footer, or
+                      contact support if the problem persists.</span
+                    >
+                  </p>
+                </div>
+                <div id="awsccc-em-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-em-btn-dismiss"
+                    type="submit"
+                    aria-label="Dismiss error message modal"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Dismiss</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-em-modalOverlay"></div>
+          <div data-id="awsccc-em-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+      </div>
+    </div>
+    <div style="position: absolute; left: -999999px; top: -99999px">
+      <span id="u2f_container"></span> <span id="ap_tokenCode"></span> <span id="mfa_form"></span>
+      <span id="mfa_container"></span>
+    </div>
+    <div id="root">
+      <div
+        id="header"
+        class="zBdDUx8FRw_DiWiJVBtE"
+        data-analytics="nav-header"
+        data-analytics-type="eventContext"
+      >
+        <div>
+          <div class="awsui-context-top-navigation">
+            <header class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_narrow_k5dlb_qkzrh_162">
+              <div class="awsui_padding-box_k5dlb_qkzrh_152">
+                <div class="awsui_identity_k5dlb_qkzrh_189">
+                  <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+                    ><img
+                      role="img"
+                      src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                      alt="AWS Access Portal (AWS Smile Icon)"
+                      class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                      class="awsui_title_k5dlb_qkzrh_228"
+                    ></span
+                  ></a>
+                </div>
+                <div class="awsui_utilities_k5dlb_qkzrh_259">
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="0"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self1-1711662765899-5709"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="John"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link0-1711662765899-3918"
+                        role="button"
+                        tabindex="0"
+                        ><span>John</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="1"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self4-1711662765899-2524"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="MFA devices"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link3-1711662765899-896"
+                        href="#/devices"
+                        ><span>MFA devices</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="2"
+                    data-utility-hide="false"
+                  >
+                    <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                      ><a
+                        id="link-self7-1711662765899-9538"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="Sign out"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link6-1711662765899-516"
+                        href="#/signout"
+                        ><span>Sign out</span></a
+                      ></span
+                    >
+                  </div>
+                </div>
+              </div>
+            </header>
+          </div>
+        </div>
+      </div>
+      <div style="">
+        <div
+          class="awsui_root_lm6vo_ttnir_133 awsui_root_1fj9k_1uvk8_5"
+          style="min-height: calc(0px + 100vh)"
+        >
+          <div class="awsui_layout_lm6vo_ttnir_145">
+            <main class="awsui_layout-main_lm6vo_ttnir_155">
+              <div>
+                <div
+                  class="awsui_content-wrapper_zycdx_1sc8d_103 awsui_content-wrapper-mobile_zycdx_1sc8d_107"
+                >
+                  <div
+                    class="awsui_content-wrapper_lm6vo_ttnir_179 awsui_content-extra-top-padding_lm6vo_ttnir_187 awsui_content_1fj9k_1uvk8_21"
+                  >
+                    <div id="content-wrapper" class="D8xb6dfGpkfz6Jls9_GX">
+                      <div class="t1K3zqLzYokQtjgU2P5t" style="">
+                        <div
+                          class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_m-bottom-s_18wu0_1qbfe_879 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                        >
+                          <div
+                            class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h1_2qdw9_gej2d_150 awsui_root-no-actions_2qdw9_gej2d_138"
+                          >
+                            <div
+                              class="awsui_main_2qdw9_gej2d_160 awsui_main-variant-h1_2qdw9_gej2d_176"
+                            >
+                              <div
+                                class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h1_2qdw9_gej2d_221"
+                              >
+                                <h1
+                                  class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h1_2qdw9_gej2d_307"
+                                >
+                                  <span
+                                    class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h1_2qdw9_gej2d_330"
+                                    id="heading46-1711662766262-5985"
+                                    >AWS access portal</span
+                                  >
+                                </h1>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="awsui_root_14rmt_1ojt0_389 awsui_tabs_14rmt_1ojt0_198">
+                          <div
+                            class="awsui_tabs-header_14rmt_1ojt0_198 awsui_tabs-header-with-divider_14rmt_1ojt0_385"
+                          >
+                            <ul role="tablist" class="awsui_tabs-header-list_14rmt_1ojt0_206">
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273 awsui_tabs-tab-active_14rmt_1ojt0_378"
+                                  role="tab"
+                                  aria-selected="true"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                                  data-testid="accounts"
+                                  id="awsui-tabs-47-1711662766263-6233-accounts"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Accounts</span></span
+                                  >
+                                </button>
+                              </li>
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273"
+                                  role="tab"
+                                  aria-selected="false"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-applications-panel"
+                                  data-testid="applications"
+                                  id="awsui-tabs-47-1711662766263-6233-applications"
+                                  tabindex="-1"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Applications</span></span
+                                  >
+                                </button>
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            class="awsui_tabs-content-wrapper_14rmt_1ojt0_454 awsui_with-paddings_14rmt_1ojt0_454"
+                          >
+                            <div
+                              class="awsui_tabs-content_14rmt_1ojt0_430 awsui_tabs-content-active_14rmt_1ojt0_440"
+                              role="tabpanel"
+                              id="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                              tabindex="0"
+                              aria-labelledby="awsui-tabs-47-1711662766263-6233-accounts"
+                            >
+                              <div
+                                class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-s_18582_uh010_158"
+                              >
+                                <div class="awsui_child_18582_uh010_103"></div>
+                                <div class="awsui_child_18582_uh010_103">
+                                  <div
+                                    class="awsui_root_14iqq_1w23c_103 awsui_variant-default_14iqq_1w23c_147"
+                                  >
+                                    <div
+                                      id="49-1711662766293-5856"
+                                      class="awsui_content-wrapper_14iqq_1w23c_222"
+                                    >
+                                      <div
+                                        class="awsui_header_14iqq_1w23c_261 awsui_with-paddings_14iqq_1w23c_301"
+                                      >
+                                        <div
+                                          data-analytics="accounts-list-header"
+                                          data-analytics-type="eventContext"
+                                          class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xs_18582_uh010_155"
+                                        >
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div
+                                              class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h2_2qdw9_gej2d_141 awsui_root-no-actions_2qdw9_gej2d_138"
+                                            >
+                                              <div class="awsui_main_2qdw9_gej2d_160">
+                                                <div
+                                                  class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h2_2qdw9_gej2d_228"
+                                                >
+                                                  <h2
+                                                    class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h2_2qdw9_gej2d_312"
+                                                  >
+                                                    <span
+                                                      data-analytics-funnel-key="substep-name"
+                                                      class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h2_2qdw9_gej2d_338"
+                                                      id="heading50-1711662766293-7070"
+                                                      ><span>AWS accounts (3)</span></span
+                                                    >
+                                                  </h2>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div class="awsui_grid_14yj0_63b5v_99">
+                                              <div
+                                                class="awsui_grid-column_14yj0_63b5v_143 awsui_colspan-12_14yj0_63b5v_264"
+                                              >
+                                                <div
+                                                  class="awsui_restore-pointer-events_14yj0_63b5v_314"
+                                                >
+                                                  <div class="BsOvt3K1aqEszThhXAnd">
+                                                    <div
+                                                      data-testid="list-header-text-filter"
+                                                      data-analytics="list-header-text-filter"
+                                                      data-analytics-type="eventDetail"
+                                                      class="awsui_root_1sdq3_1cqzf_99"
+                                                    >
+                                                      <div
+                                                        class="awsui_input_1sdq3_1cqzf_137 awsui_input-container_2rhyz_qevde_262"
+                                                      >
+                                                        <span
+                                                          class="awsui_input-icon-left_2rhyz_qevde_267"
+                                                          ><span
+                                                            class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-subtle_h11ix_obmua_239"
+                                                            ><svg
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                              viewBox="0 0 16 16"
+                                                              focusable="false"
+                                                              aria-hidden="true"
+                                                            >
+                                                              <circle cx="7" cy="7" r="5"></circle>
+                                                              <path
+                                                                d="m15 15-4.5-4.5"
+                                                              ></path></svg></span></span
+                                                        ><input
+                                                          aria-label="Filter accounts by name, ID, or email address"
+                                                          placeholder="Filter accounts by name, ID, or email address"
+                                                          class="awsui_input_2rhyz_qevde_103 awsui_input-type-search_2rhyz_qevde_236 awsui_input-has-icon-left_2rhyz_qevde_231"
+                                                          autocomplete="off"
+                                                          type="search"
+                                                          value=""
+                                                        />
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div class="awsui_content_14iqq_1w23c_222">
+                                        <div data-testid="account-list">
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Development</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      987654321098 | aws-development@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=987654321098&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Production</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      123456789012 | aws-production@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=123456789012&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Root</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      234567890123 | aws-root@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=ReadOnlyAccess"
+                                                    >ReadOnlyAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="awsui_tabs-content_14rmt_1ojt0_430"
+                            role="tabpanel"
+                            id="awsui-tabs-47-1711662766263-6233-applications-panel"
+                            tabindex="0"
+                            aria-labelledby="awsui-tabs-47-1711662766263-6233-applications"
+                          ></div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
+      </div>
+      <div
+        id="footer"
+        class="A3g9fuQWIhSmqmpMV_H8"
+        data-analytics="nav-footer"
+        data-analytics-type="eventContext"
+      >
+        <div class="NKvyJBFp1PzWTL6f_OWR">
+          <a
+            id="link-self10-1711662765900-7179"
+            data-testid="feedback-link"
+            data-analytics="footer-link-feedback"
+            data-analytics-type="eventDetail"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link9-1711662765900-5024"
+            role="button"
+            tabindex="0"
+            >Feedback</a
+          >
+        </div>
+        <div class="AwKnBv8vVIbohRP_1Nex">
+          <div
+            class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-inherit_18wu0_1qbfe_360 awsui_font-size-body-s_18wu0_1qbfe_363 awsui_font-weight-default_18wu0_1qbfe_275"
+          >
+            ©2024, Amazon Web Services, Inc. or its affiliates. All rights reserved.
+          </div>
+        </div>
+        <div class="NKvyJBFp1PzWTL6f_OWR QDppO6mR7sx8I2Tm0f_n">
+          <a
+            id="link-self13-1711662765900-718"
+            data-analytics="footer-link-privacy"
+            data-analytics-type="eventDetail"
+            data-testid="privacy-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link12-1711662765900-8218"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/privacy/"
+            >Privacy</a
+          ><a
+            id="link-self16-1711662765900-8033"
+            data-analytics="footer-link-terms"
+            data-analytics-type="eventDetail"
+            data-testid="terms-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link15-1711662765900-8357"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/terms/"
+            >Terms</a
+          ><a
+            id="link-self19-1711662765900-6302"
+            data-analytics="footer-link-cookie-preferences"
+            data-analytics-type="eventDetail"
+            data-testid="cookie-preferences-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link18-1711662765900-5299"
+            role="button"
+            tabindex="0"
+            >Cookie Preferences</a
+          >
+        </div>
+      </div>
+    </div>
+    <div
+      id="awsc-aperture-widget-tracker-container"
+      data-analytics-widget-id="awsc-aperture-widget-modal"
+    >
+      <div id="awsc-aperture-widget-modal-container"></div>
+    </div>
+    <div>
+      <div
+        aria-hidden="true"
+        class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_virtual_k5dlb_qkzrh_173 awsui_hidden_k5dlb_qkzrh_177 awsui_narrow_k5dlb_qkzrh_162"
+      >
+        <div class="awsui_padding-box_k5dlb_qkzrh_152">
+          <div class="awsui_identity_k5dlb_qkzrh_189">
+            <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+              ><img
+                role="img"
+                src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                alt="AWS Access Portal (AWS Smile Icon)"
+                class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                class="awsui_title_k5dlb_qkzrh_228"
+              ></span
+            ></a>
+          </div>
+          <div class="awsui_utilities_k5dlb_qkzrh_259">
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="search"
+            >
+              <span
+                ><a
+                  id="link-self22-1711662765904-5989"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Search"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link21-1711662765904-9226"
+                  role="button"
+                  tabindex="0"
+                  ><span
+                    class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                    ><svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 16 16"
+                      focusable="false"
+                      aria-hidden="true"
+                    >
+                      <circle cx="7" cy="7" r="5"></circle>
+                      <path d="m15 15-4.5-4.5"></path></svg></span></a
+              ></span>
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self25-1711662765905-1512"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link24-1711662765905-5182"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self28-1711662765905-9207"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link27-1711662765905-5996"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="false"
+            >
+              <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                ><a
+                  id="link-self31-1711662765905-9830"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link30-1711662765905-9861"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self34-1711662765905-1739"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link33-1711662765905-8834"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self37-1711662765905-9176"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link36-1711662765905-6389"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self40-1711662765905-8633"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link39-1711662765905-4901"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-menu-dropdown_k5dlb_qkzrh_296 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="menu-trigger"
+            >
+              <button
+                type="button"
+                class="awsui_button_m5h9f_r0dm2_99 awsui_offset-right-l_m5h9f_r0dm2_168"
+                aria-expanded="false"
+                aria-haspopup="true"
+              >
+                <span class="awsui_text_m5h9f_r0dm2_196">More</span
+                ><span
+                  class="awsui_rotate-down_sne0l_lqyym_137 awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                  ><svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    focusable="false"
+                    aria-hidden="true"
+                  >
+                    <path class="filled stroke-linejoin-round" d="M4 5h8l-4 6-4-6z"></path></svg
+                ></span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/test_files/aws_portal.new.mysso.folded_sections.html
+++ b/tests/test_files/aws_portal.new.mysso.folded_sections.html
@@ -1,0 +1,1299 @@
+<html lang="en" class="osfqxsm idc0_350">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; object-src 'none'; base-uri 'self'; img-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://static.global.sso.amazonaws.com/ data: 'self'; script-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.cdn.uis.awsstatic.com/ https://*.cdn.console.awsstatic.com/ https://*.shortbread.aws.dev/ 'self'; style-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.shortbread.aws.dev/ 'self' 'unsafe-inline'; font-src https://assets.sso-portal.eu-west-1.amazonaws.com/ data: 'self'; connect-src https://portal.sso.eu-west-1.amazonaws.com https://oidc.eu-west-1.amazonaws.com https://up.sso.eu-west-1.amazonaws.com https://log.sso-portal.eu-west-1.amazonaws.com https://*.analytics.console.aws.a2z.com https://*.feedback.console.aws.dev https://*.shortbread.aws.dev/ 'self';"
+    />
+    <title>AWS access portal</title>
+    <meta name="version" content="2" />
+  </head>
+
+  <body data-new-gr-c-s-check-loaded="8.911.0" data-gr-ext-installed="">
+    <div id="awsccc-sb-ux-c">
+      <div id="awsccc-sb-a" class="">
+        <div data-id="awsccc-cb" style="display: none">
+          <div
+            id="awsccc-cb-c"
+            data-id="awsccc-cb-tabstart"
+            class="awsccc-tab-helper"
+            tabindex="-1"
+          >
+            <div id="awsccc-cb-content">
+              <div id="awsccc-cb-text-section">
+                <h2 id="awsccc-cb-title">Select your cookie preferences</h2>
+                <p id="awsccc-cb-text">
+                  <span
+                    >We use essential cookies and similar tools that are necessary to provide our
+                    site and services. We use performance cookies to collect anonymous statistics so
+                    we can understand how customers use our site and make improvements. Essential
+                    cookies cannot be deactivated, but you can click “Customize cookies” to decline
+                    performance cookies. <br /><br />
+                    If you agree, AWS and approved third parties will also use cookies to provide
+                    useful site features, remember your preferences, and display relevant content,
+                    including relevant advertising. To continue without accepting these cookies,
+                    click “Continue without accepting.” To make more detailed choices or learn more,
+                    click “Customize cookies.”</span
+                  >
+                </p>
+              </div>
+              <div id="awsccc-cb-actions">
+                <div id="awsccc-cb-buttons">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-accept"
+                    type="submit"
+                    aria-label="Accept all cookies"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Accept all cookies</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-continue"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Continue without accepting</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-customize"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Customize cookies</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div data-id="awsccc-cs" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-cs-container"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Customize cookie preferences"
+            data-awsccc-modal-toggle="true"
+            data-id="awsccc-cs-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-cs-container-inner">
+              <div id="awsccc-cs-content">
+                <div id="awsccc-cs-header">
+                  <div id="awsccc-cs-title">
+                    <h2>Customize cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-cs-modalBody">
+                  <div id="awsccc-cs-i-container">
+                    <span
+                      >We use cookies and similar tools (collectively, "cookies") for the following
+                      purposes.</span
+                    >
+                  </div>
+                  <div data-category="essential" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Essential</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Essential cookies are necessary to provide our site and services and cannot
+                        be deactivated. They are usually set in response to your actions on the
+                        site, such as setting your privacy preferences, signing in, or filling in
+                        forms.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action"></div>
+                  </div>
+                  <div data-category="performance" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Performance</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Performance cookies provide anonymous statistics about how customers
+                        navigate our site so we can improve site experience and performance.
+                        Approved third parties may perform analytics on our behalf, but they cannot
+                        use the data for their own purposes.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-performance-container"
+                          >
+                            <label data-id="awsccc-u-cb-performance-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-performance"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow performance category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="functional" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Functional</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Functional cookies help us provide useful site features, remember your
+                        preferences, and display relevant content. Approved third parties may set
+                        these cookies to provide certain site features. If you do not allow these
+                        cookies, then some or all of these services may not function properly.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-functional-container"
+                          >
+                            <label data-id="awsccc-u-cb-functional-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-functional"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow functional category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="advertising" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Advertising</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Advertising cookies may be set through our site by us or our advertising
+                        partners and help us deliver relevant marketing content. If you do not allow
+                        these cookies, you will experience less relevant advertising.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-advertising-container"
+                          >
+                            <label data-id="awsccc-u-cb-advertising-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-advertising"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow advertising category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="awsccc-cs-l-container">
+                    <p>
+                      <span
+                        >Blocking some types of cookies may impact your experience of our sites. You
+                        may review and change your choices at any time by clicking Cookie
+                        preferences in the footer of this site. We and selected third-parties use
+                        cookies or similar technologies as specified in the&nbsp;<a
+                          data-id="awsccc-cs-f-notice"
+                          href="https://aws.amazon.com/legal/cookies/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          ><span
+                            >AWS Cookie Notice<span
+                              aria-label="Opens in a new Window"
+                              role="img"
+                              class="awsccc-u-i-open-c"
+                              ><svg
+                                class="awsccc-u-i-open"
+                                viewBox="0 0 16 16"
+                                focusable="false"
+                                aria-hidden="true"
+                              >
+                                <path class="awsccc-stroke-linecap-square" d="M10 2h4v4"></path>
+                                <path d="M6 10l8-8"></path>
+                                <path
+                                  class="awsccc-stroke-linejoin-round"
+                                  d="M14 9.048V14H2V2h5"
+                                ></path></svg></span></span></a
+                        >.</span
+                      >
+                    </p>
+                  </div>
+                </div>
+                <div id="awsccc-cs-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-cancel"
+                    type="submit"
+                    aria-label="Cancel customizing cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Cancel</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-save"
+                    type="submit"
+                    aria-label="Save customized cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Save preferences</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-cs-modalOverlay"></div>
+          <div data-id="awsccc-cs-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+        <div data-id="awsccc-em-modal" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-em-container"
+            role="dialog"
+            aria-modal="true"
+            data-awsccc-emm-modal-toggle="true"
+            data-id="awsccc-em-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-em-container-inner">
+              <div id="awsccc-em-content">
+                <div id="awsccc-em-header">
+                  <div id="awsccc-em-title">
+                    <h2>Unable to save cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-em-modalBody">
+                  <p id="awsccc-emm-paragraph">
+                    <span
+                      >We will only store essential cookies at this time, because we were unable to
+                      save your cookie preferences.<br /><br />If you want to change your cookie
+                      preferences, try again later using the link in the AWS console footer, or
+                      contact support if the problem persists.</span
+                    >
+                  </p>
+                </div>
+                <div id="awsccc-em-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-em-btn-dismiss"
+                    type="submit"
+                    aria-label="Dismiss error message modal"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Dismiss</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-em-modalOverlay"></div>
+          <div data-id="awsccc-em-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+      </div>
+    </div>
+    <div style="position: absolute; left: -999999px; top: -99999px">
+      <span id="u2f_container"></span> <span id="ap_tokenCode"></span> <span id="mfa_form"></span>
+      <span id="mfa_container"></span>
+    </div>
+    <div id="root">
+      <div
+        id="header"
+        class="zBdDUx8FRw_DiWiJVBtE"
+        data-analytics="nav-header"
+        data-analytics-type="eventContext"
+      >
+        <div>
+          <div class="awsui-context-top-navigation">
+            <header class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_narrow_k5dlb_qkzrh_162">
+              <div class="awsui_padding-box_k5dlb_qkzrh_152">
+                <div class="awsui_identity_k5dlb_qkzrh_189">
+                  <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+                    ><img
+                      role="img"
+                      src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                      alt="AWS Access Portal (AWS Smile Icon)"
+                      class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                      class="awsui_title_k5dlb_qkzrh_228"
+                    ></span
+                  ></a>
+                </div>
+                <div class="awsui_utilities_k5dlb_qkzrh_259">
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="0"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self1-1711662765899-5709"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="John"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link0-1711662765899-3918"
+                        role="button"
+                        tabindex="0"
+                        ><span>John</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="1"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self4-1711662765899-2524"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="MFA devices"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link3-1711662765899-896"
+                        href="#/devices"
+                        ><span>MFA devices</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="2"
+                    data-utility-hide="false"
+                  >
+                    <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                      ><a
+                        id="link-self7-1711662765899-9538"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="Sign out"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link6-1711662765899-516"
+                        href="#/signout"
+                        ><span>Sign out</span></a
+                      ></span
+                    >
+                  </div>
+                </div>
+              </div>
+            </header>
+          </div>
+        </div>
+      </div>
+      <div style="">
+        <div
+          class="awsui_root_lm6vo_ttnir_133 awsui_root_1fj9k_1uvk8_5"
+          style="min-height: calc(0px + 100vh)"
+        >
+          <div class="awsui_layout_lm6vo_ttnir_145">
+            <main class="awsui_layout-main_lm6vo_ttnir_155">
+              <div>
+                <div
+                  class="awsui_content-wrapper_zycdx_1sc8d_103 awsui_content-wrapper-mobile_zycdx_1sc8d_107"
+                >
+                  <div
+                    class="awsui_content-wrapper_lm6vo_ttnir_179 awsui_content-extra-top-padding_lm6vo_ttnir_187 awsui_content_1fj9k_1uvk8_21"
+                  >
+                    <div id="content-wrapper" class="D8xb6dfGpkfz6Jls9_GX">
+                      <div class="t1K3zqLzYokQtjgU2P5t" style="">
+                        <div
+                          class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_m-bottom-s_18wu0_1qbfe_879 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                        >
+                          <div
+                            class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h1_2qdw9_gej2d_150 awsui_root-no-actions_2qdw9_gej2d_138"
+                          >
+                            <div
+                              class="awsui_main_2qdw9_gej2d_160 awsui_main-variant-h1_2qdw9_gej2d_176"
+                            >
+                              <div
+                                class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h1_2qdw9_gej2d_221"
+                              >
+                                <h1
+                                  class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h1_2qdw9_gej2d_307"
+                                >
+                                  <span
+                                    class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h1_2qdw9_gej2d_330"
+                                    id="heading46-1711662766262-5985"
+                                    >AWS access portal</span
+                                  >
+                                </h1>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="awsui_root_14rmt_1ojt0_389 awsui_tabs_14rmt_1ojt0_198">
+                          <div
+                            class="awsui_tabs-header_14rmt_1ojt0_198 awsui_tabs-header-with-divider_14rmt_1ojt0_385"
+                          >
+                            <ul role="tablist" class="awsui_tabs-header-list_14rmt_1ojt0_206">
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273 awsui_tabs-tab-active_14rmt_1ojt0_378"
+                                  role="tab"
+                                  aria-selected="true"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                                  data-testid="accounts"
+                                  id="awsui-tabs-47-1711662766263-6233-accounts"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Accounts</span></span
+                                  >
+                                </button>
+                              </li>
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273"
+                                  role="tab"
+                                  aria-selected="false"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-applications-panel"
+                                  data-testid="applications"
+                                  id="awsui-tabs-47-1711662766263-6233-applications"
+                                  tabindex="-1"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Applications</span></span
+                                  >
+                                </button>
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            class="awsui_tabs-content-wrapper_14rmt_1ojt0_454 awsui_with-paddings_14rmt_1ojt0_454"
+                          >
+                            <div
+                              class="awsui_tabs-content_14rmt_1ojt0_430 awsui_tabs-content-active_14rmt_1ojt0_440"
+                              role="tabpanel"
+                              id="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                              tabindex="0"
+                              aria-labelledby="awsui-tabs-47-1711662766263-6233-accounts"
+                            >
+                              <div
+                                class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-s_18582_uh010_158"
+                              >
+                                <div class="awsui_child_18582_uh010_103"></div>
+                                <div class="awsui_child_18582_uh010_103">
+                                  <div
+                                    class="awsui_root_14iqq_1w23c_103 awsui_variant-default_14iqq_1w23c_147"
+                                  >
+                                    <div
+                                      id="49-1711662766293-5856"
+                                      class="awsui_content-wrapper_14iqq_1w23c_222"
+                                    >
+                                      <div
+                                        class="awsui_header_14iqq_1w23c_261 awsui_with-paddings_14iqq_1w23c_301"
+                                      >
+                                        <div
+                                          data-analytics="accounts-list-header"
+                                          data-analytics-type="eventContext"
+                                          class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xs_18582_uh010_155"
+                                        >
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div
+                                              class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h2_2qdw9_gej2d_141 awsui_root-no-actions_2qdw9_gej2d_138"
+                                            >
+                                              <div class="awsui_main_2qdw9_gej2d_160">
+                                                <div
+                                                  class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h2_2qdw9_gej2d_228"
+                                                >
+                                                  <h2
+                                                    class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h2_2qdw9_gej2d_312"
+                                                  >
+                                                    <span
+                                                      data-analytics-funnel-key="substep-name"
+                                                      class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h2_2qdw9_gej2d_338"
+                                                      id="heading50-1711662766293-7070"
+                                                      ><span>AWS accounts (3)</span></span
+                                                    >
+                                                  </h2>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div class="awsui_grid_14yj0_63b5v_99">
+                                              <div
+                                                class="awsui_grid-column_14yj0_63b5v_143 awsui_colspan-12_14yj0_63b5v_264"
+                                              >
+                                                <div
+                                                  class="awsui_restore-pointer-events_14yj0_63b5v_314"
+                                                >
+                                                  <div class="BsOvt3K1aqEszThhXAnd">
+                                                    <div
+                                                      data-testid="list-header-text-filter"
+                                                      data-analytics="list-header-text-filter"
+                                                      data-analytics-type="eventDetail"
+                                                      class="awsui_root_1sdq3_1cqzf_99"
+                                                    >
+                                                      <div
+                                                        class="awsui_input_1sdq3_1cqzf_137 awsui_input-container_2rhyz_qevde_262"
+                                                      >
+                                                        <span
+                                                          class="awsui_input-icon-left_2rhyz_qevde_267"
+                                                          ><span
+                                                            class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-subtle_h11ix_obmua_239"
+                                                            ><svg
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                              viewBox="0 0 16 16"
+                                                              focusable="false"
+                                                              aria-hidden="true"
+                                                            >
+                                                              <circle cx="7" cy="7" r="5"></circle>
+                                                              <path
+                                                                d="m15 15-4.5-4.5"
+                                                              ></path></svg></span></span
+                                                        ><input
+                                                          aria-label="Filter accounts by name, ID, or email address"
+                                                          placeholder="Filter accounts by name, ID, or email address"
+                                                          class="awsui_input_2rhyz_qevde_103 awsui_input-type-search_2rhyz_qevde_236 awsui_input-has-icon-left_2rhyz_qevde_231"
+                                                          autocomplete="off"
+                                                          type="search"
+                                                          value=""
+                                                        />
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div class="awsui_content_14iqq_1w23c_222">
+                                        <div data-testid="account-list">
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="false"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Development</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      987654321098 | aws-development@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=987654321098&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="false"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Production</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      123456789012 | aws-production@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=123456789012&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="false"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Root</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      234567890123 | aws-root@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=ReadOnlyAccess"
+                                                    >ReadOnlyAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="awsui_tabs-content_14rmt_1ojt0_430"
+                            role="tabpanel"
+                            id="awsui-tabs-47-1711662766263-6233-applications-panel"
+                            tabindex="0"
+                            aria-labelledby="awsui-tabs-47-1711662766263-6233-applications"
+                          ></div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
+      </div>
+      <div
+        id="footer"
+        class="A3g9fuQWIhSmqmpMV_H8"
+        data-analytics="nav-footer"
+        data-analytics-type="eventContext"
+      >
+        <div class="NKvyJBFp1PzWTL6f_OWR">
+          <a
+            id="link-self10-1711662765900-7179"
+            data-testid="feedback-link"
+            data-analytics="footer-link-feedback"
+            data-analytics-type="eventDetail"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link9-1711662765900-5024"
+            role="button"
+            tabindex="0"
+            >Feedback</a
+          >
+        </div>
+        <div class="AwKnBv8vVIbohRP_1Nex">
+          <div
+            class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-inherit_18wu0_1qbfe_360 awsui_font-size-body-s_18wu0_1qbfe_363 awsui_font-weight-default_18wu0_1qbfe_275"
+          >
+            ©2024, Amazon Web Services, Inc. or its affiliates. All rights reserved.
+          </div>
+        </div>
+        <div class="NKvyJBFp1PzWTL6f_OWR QDppO6mR7sx8I2Tm0f_n">
+          <a
+            id="link-self13-1711662765900-718"
+            data-analytics="footer-link-privacy"
+            data-analytics-type="eventDetail"
+            data-testid="privacy-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link12-1711662765900-8218"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/privacy/"
+            >Privacy</a
+          ><a
+            id="link-self16-1711662765900-8033"
+            data-analytics="footer-link-terms"
+            data-analytics-type="eventDetail"
+            data-testid="terms-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link15-1711662765900-8357"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/terms/"
+            >Terms</a
+          ><a
+            id="link-self19-1711662765900-6302"
+            data-analytics="footer-link-cookie-preferences"
+            data-analytics-type="eventDetail"
+            data-testid="cookie-preferences-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link18-1711662765900-5299"
+            role="button"
+            tabindex="0"
+            >Cookie Preferences</a
+          >
+        </div>
+      </div>
+    </div>
+    <div
+      id="awsc-aperture-widget-tracker-container"
+      data-analytics-widget-id="awsc-aperture-widget-modal"
+    >
+      <div id="awsc-aperture-widget-modal-container"></div>
+    </div>
+    <div>
+      <div
+        aria-hidden="true"
+        class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_virtual_k5dlb_qkzrh_173 awsui_hidden_k5dlb_qkzrh_177 awsui_narrow_k5dlb_qkzrh_162"
+      >
+        <div class="awsui_padding-box_k5dlb_qkzrh_152">
+          <div class="awsui_identity_k5dlb_qkzrh_189">
+            <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+              ><img
+                role="img"
+                src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                alt="AWS Access Portal (AWS Smile Icon)"
+                class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                class="awsui_title_k5dlb_qkzrh_228"
+              ></span
+            ></a>
+          </div>
+          <div class="awsui_utilities_k5dlb_qkzrh_259">
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="search"
+            >
+              <span
+                ><a
+                  id="link-self22-1711662765904-5989"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Search"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link21-1711662765904-9226"
+                  role="button"
+                  tabindex="0"
+                  ><span
+                    class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                    ><svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 16 16"
+                      focusable="false"
+                      aria-hidden="true"
+                    >
+                      <circle cx="7" cy="7" r="5"></circle>
+                      <path d="m15 15-4.5-4.5"></path></svg></span></a
+              ></span>
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self25-1711662765905-1512"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link24-1711662765905-5182"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self28-1711662765905-9207"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link27-1711662765905-5996"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="false"
+            >
+              <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                ><a
+                  id="link-self31-1711662765905-9830"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link30-1711662765905-9861"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self34-1711662765905-1739"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link33-1711662765905-8834"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self37-1711662765905-9176"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link36-1711662765905-6389"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self40-1711662765905-8633"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link39-1711662765905-4901"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-menu-dropdown_k5dlb_qkzrh_296 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="menu-trigger"
+            >
+              <button
+                type="button"
+                class="awsui_button_m5h9f_r0dm2_99 awsui_offset-right-l_m5h9f_r0dm2_168"
+                aria-expanded="false"
+                aria-haspopup="true"
+              >
+                <span class="awsui_text_m5h9f_r0dm2_196">More</span
+                ><span
+                  class="awsui_rotate-down_sne0l_lqyym_137 awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                  ><svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    focusable="false"
+                    aria-hidden="true"
+                  >
+                    <path class="filled stroke-linejoin-round" d="M4 5h8l-4 6-4-6z"></path></svg
+                ></span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/test_files/aws_portal.new.mysso.html
+++ b/tests/test_files/aws_portal.new.mysso.html
@@ -1,0 +1,1299 @@
+<html lang="en" class="osfqxsm idc0_350">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; object-src 'none'; base-uri 'self'; img-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://static.global.sso.amazonaws.com/ data: 'self'; script-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.cdn.uis.awsstatic.com/ https://*.cdn.console.awsstatic.com/ https://*.shortbread.aws.dev/ 'self'; style-src https://assets.sso-portal.eu-west-1.amazonaws.com/ https://*.shortbread.aws.dev/ 'self' 'unsafe-inline'; font-src https://assets.sso-portal.eu-west-1.amazonaws.com/ data: 'self'; connect-src https://portal.sso.eu-west-1.amazonaws.com https://oidc.eu-west-1.amazonaws.com https://up.sso.eu-west-1.amazonaws.com https://log.sso-portal.eu-west-1.amazonaws.com https://*.analytics.console.aws.a2z.com https://*.feedback.console.aws.dev https://*.shortbread.aws.dev/ 'self';"
+    />
+    <title>AWS access portal</title>
+    <meta name="version" content="2" />
+  </head>
+
+  <body data-new-gr-c-s-check-loaded="8.911.0" data-gr-ext-installed="">
+    <div id="awsccc-sb-ux-c">
+      <div id="awsccc-sb-a" class="">
+        <div data-id="awsccc-cb" style="display: none">
+          <div
+            id="awsccc-cb-c"
+            data-id="awsccc-cb-tabstart"
+            class="awsccc-tab-helper"
+            tabindex="-1"
+          >
+            <div id="awsccc-cb-content">
+              <div id="awsccc-cb-text-section">
+                <h2 id="awsccc-cb-title">Select your cookie preferences</h2>
+                <p id="awsccc-cb-text">
+                  <span
+                    >We use essential cookies and similar tools that are necessary to provide our
+                    site and services. We use performance cookies to collect anonymous statistics so
+                    we can understand how customers use our site and make improvements. Essential
+                    cookies cannot be deactivated, but you can click “Customize cookies” to decline
+                    performance cookies. <br /><br />
+                    If you agree, AWS and approved third parties will also use cookies to provide
+                    useful site features, remember your preferences, and display relevant content,
+                    including relevant advertising. To continue without accepting these cookies,
+                    click “Continue without accepting.” To make more detailed choices or learn more,
+                    click “Customize cookies.”</span
+                  >
+                </p>
+              </div>
+              <div id="awsccc-cb-actions">
+                <div id="awsccc-cb-buttons">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-accept"
+                    type="submit"
+                    aria-label="Accept all cookies"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Accept all cookies</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-continue"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Continue without accepting</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cb-btn-customize"
+                    type="submit"
+                    aria-label="Customize cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Customize cookies</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div data-id="awsccc-cs" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-cs-container"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Customize cookie preferences"
+            data-awsccc-modal-toggle="true"
+            data-id="awsccc-cs-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-cs-container-inner">
+              <div id="awsccc-cs-content">
+                <div id="awsccc-cs-header">
+                  <div id="awsccc-cs-title">
+                    <h2>Customize cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-cs-modalBody">
+                  <div id="awsccc-cs-i-container">
+                    <span
+                      >We use cookies and similar tools (collectively, "cookies") for the following
+                      purposes.</span
+                    >
+                  </div>
+                  <div data-category="essential" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Essential</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Essential cookies are necessary to provide our site and services and cannot
+                        be deactivated. They are usually set in response to your actions on the
+                        site, such as setting your privacy preferences, signing in, or filling in
+                        forms.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action"></div>
+                  </div>
+                  <div data-category="performance" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Performance</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Performance cookies provide anonymous statistics about how customers
+                        navigate our site so we can improve site experience and performance.
+                        Approved third parties may perform analytics on our behalf, but they cannot
+                        use the data for their own purposes.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-performance-container"
+                          >
+                            <label data-id="awsccc-u-cb-performance-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-performance"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow performance category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="functional" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Functional</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Functional cookies help us provide useful site features, remember your
+                        preferences, and display relevant content. Approved third parties may set
+                        these cookies to provide certain site features. If you do not allow these
+                        cookies, then some or all of these services may not function properly.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-functional-container"
+                          >
+                            <label data-id="awsccc-u-cb-functional-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-functional"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow functional category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div data-category="advertising" class="awsccc-cs-s-container">
+                    <h3 class="awsccc-cs-s-title">Advertising</h3>
+                    <div class="awsccc-cs-s-text">
+                      <p class="awsccc-cs-s-paragraph">
+                        Advertising cookies may be set through our site by us or our advertising
+                        partners and help us deliver relevant marketing content. If you do not allow
+                        these cookies, you will experience less relevant advertising.
+                      </p>
+                    </div>
+                    <div class="awsccc-cs-s-action">
+                      <div>
+                        <div class="awsccc-cs-s-cb-outer">
+                          <div
+                            class="awscc-u-cb-checkbox-container"
+                            data-id="awsccc-u-cb-advertising-container"
+                          >
+                            <label data-id="awsccc-u-cb-advertising-label" class="awsccc-u-cb-label"
+                              ><input
+                                id="awsccc-u-cb-advertising"
+                                class="awsccc-u-cb-input"
+                                type="checkbox"
+                                aria-checked="false" /><span class="awsccc-cs-s-cb-hidden"
+                                >Allow advertising category</span
+                              ><svg
+                                viewBox="0 0 14 14"
+                                aria-hidden="true"
+                                focusable="false"
+                                class="awscc-u-cb-checkbox"
+                              >
+                                <rect
+                                  class="awscc-u-cb-checkbox-rect"
+                                  x="0.5"
+                                  y="0.5"
+                                  rx="1.5"
+                                  ry="1.5"
+                                  width="13"
+                                  height="13"
+                                ></rect>
+                                <polyline
+                                  class="awscc-u-cb-checkbox-poly-line"
+                                  points="2.5,7 6,10 11,3"
+                                ></polyline></svg
+                            ></label>
+                          </div>
+                        </div>
+                        <span class="awsccc-u-cb-text">Allowed</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div id="awsccc-cs-l-container">
+                    <p>
+                      <span
+                        >Blocking some types of cookies may impact your experience of our sites. You
+                        may review and change your choices at any time by clicking Cookie
+                        preferences in the footer of this site. We and selected third-parties use
+                        cookies or similar technologies as specified in the&nbsp;<a
+                          data-id="awsccc-cs-f-notice"
+                          href="https://aws.amazon.com/legal/cookies/"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          ><span
+                            >AWS Cookie Notice<span
+                              aria-label="Opens in a new Window"
+                              role="img"
+                              class="awsccc-u-i-open-c"
+                              ><svg
+                                class="awsccc-u-i-open"
+                                viewBox="0 0 16 16"
+                                focusable="false"
+                                aria-hidden="true"
+                              >
+                                <path class="awsccc-stroke-linecap-square" d="M10 2h4v4"></path>
+                                <path d="M6 10l8-8"></path>
+                                <path
+                                  class="awsccc-stroke-linejoin-round"
+                                  d="M14 9.048V14H2V2h5"
+                                ></path></svg></span></span></a
+                        >.</span
+                      >
+                    </p>
+                  </div>
+                </div>
+                <div id="awsccc-cs-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-cancel"
+                    type="submit"
+                    aria-label="Cancel customizing cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-secondary"
+                  >
+                    <span>Cancel</span></button
+                  ><button
+                    tabindex="0"
+                    data-id="awsccc-cs-btn-save"
+                    type="submit"
+                    aria-label="Save customized cookie preferences"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Save preferences</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-cs-modalOverlay"></div>
+          <div data-id="awsccc-cs-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+        <div data-id="awsccc-em-modal" style="display: none" tabindex="0" class="">
+          <div
+            id="awsccc-em-container"
+            role="dialog"
+            aria-modal="true"
+            data-awsccc-emm-modal-toggle="true"
+            data-id="awsccc-em-tabtrap"
+            tabindex="-1"
+          >
+            <div id="awsccc-em-container-inner">
+              <div id="awsccc-em-content">
+                <div id="awsccc-em-header">
+                  <div id="awsccc-em-title">
+                    <h2>Unable to save cookie preferences</h2>
+                  </div>
+                </div>
+                <div id="awsccc-em-modalBody">
+                  <p id="awsccc-emm-paragraph">
+                    <span
+                      >We will only store essential cookies at this time, because we were unable to
+                      save your cookie preferences.<br /><br />If you want to change your cookie
+                      preferences, try again later using the link in the AWS console footer, or
+                      contact support if the problem persists.</span
+                    >
+                  </p>
+                </div>
+                <div id="awsccc-em-f-c">
+                  <button
+                    tabindex="0"
+                    data-id="awsccc-em-btn-dismiss"
+                    type="submit"
+                    aria-label="Dismiss error message modal"
+                    class="awsccc-u-btn awsccc-u-btn-primary"
+                  >
+                    <span>Dismiss</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="awsccc-em-modalOverlay"></div>
+          <div data-id="awsccc-em-tabtrap" tabindex="-1" class="awsccc-tab-helper"></div>
+        </div>
+      </div>
+    </div>
+    <div style="position: absolute; left: -999999px; top: -99999px">
+      <span id="u2f_container"></span> <span id="ap_tokenCode"></span> <span id="mfa_form"></span>
+      <span id="mfa_container"></span>
+    </div>
+    <div id="root">
+      <div
+        id="header"
+        class="zBdDUx8FRw_DiWiJVBtE"
+        data-analytics="nav-header"
+        data-analytics-type="eventContext"
+      >
+        <div>
+          <div class="awsui-context-top-navigation">
+            <header class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_narrow_k5dlb_qkzrh_162">
+              <div class="awsui_padding-box_k5dlb_qkzrh_152">
+                <div class="awsui_identity_k5dlb_qkzrh_189">
+                  <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+                    ><img
+                      role="img"
+                      src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                      alt="AWS Access Portal (AWS Smile Icon)"
+                      class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                      class="awsui_title_k5dlb_qkzrh_228"
+                    ></span
+                  ></a>
+                </div>
+                <div class="awsui_utilities_k5dlb_qkzrh_259">
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="0"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self1-1711662765899-5709"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="John"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link0-1711662765899-3918"
+                        role="button"
+                        tabindex="0"
+                        ><span>John</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="1"
+                    data-utility-hide="false"
+                  >
+                    <span
+                      ><a
+                        id="link-self4-1711662765899-2524"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="MFA devices"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link3-1711662765899-896"
+                        href="#/devices"
+                        ><span>MFA devices</span></a
+                      ></span
+                    >
+                  </div>
+                  <div
+                    class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+                    data-utility-index="2"
+                    data-utility-hide="false"
+                  >
+                    <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                      ><a
+                        id="link-self7-1711662765899-9538"
+                        class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                        aria-label="Sign out"
+                        aria-labelledby=""
+                        data-analytics-funnel-value="link6-1711662765899-516"
+                        href="#/signout"
+                        ><span>Sign out</span></a
+                      ></span
+                    >
+                  </div>
+                </div>
+              </div>
+            </header>
+          </div>
+        </div>
+      </div>
+      <div style="">
+        <div
+          class="awsui_root_lm6vo_ttnir_133 awsui_root_1fj9k_1uvk8_5"
+          style="min-height: calc(0px + 100vh)"
+        >
+          <div class="awsui_layout_lm6vo_ttnir_145">
+            <main class="awsui_layout-main_lm6vo_ttnir_155">
+              <div>
+                <div
+                  class="awsui_content-wrapper_zycdx_1sc8d_103 awsui_content-wrapper-mobile_zycdx_1sc8d_107"
+                >
+                  <div
+                    class="awsui_content-wrapper_lm6vo_ttnir_179 awsui_content-extra-top-padding_lm6vo_ttnir_187 awsui_content_1fj9k_1uvk8_21"
+                  >
+                    <div id="content-wrapper" class="D8xb6dfGpkfz6Jls9_GX">
+                      <div class="t1K3zqLzYokQtjgU2P5t" style="">
+                        <div
+                          class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_m-bottom-s_18wu0_1qbfe_879 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                        >
+                          <div
+                            class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h1_2qdw9_gej2d_150 awsui_root-no-actions_2qdw9_gej2d_138"
+                          >
+                            <div
+                              class="awsui_main_2qdw9_gej2d_160 awsui_main-variant-h1_2qdw9_gej2d_176"
+                            >
+                              <div
+                                class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h1_2qdw9_gej2d_221"
+                              >
+                                <h1
+                                  class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h1_2qdw9_gej2d_307"
+                                >
+                                  <span
+                                    class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h1_2qdw9_gej2d_330"
+                                    id="heading46-1711662766262-5985"
+                                    >AWS access portal</span
+                                  >
+                                </h1>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="awsui_root_14rmt_1ojt0_389 awsui_tabs_14rmt_1ojt0_198">
+                          <div
+                            class="awsui_tabs-header_14rmt_1ojt0_198 awsui_tabs-header-with-divider_14rmt_1ojt0_385"
+                          >
+                            <ul role="tablist" class="awsui_tabs-header-list_14rmt_1ojt0_206">
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273 awsui_tabs-tab-active_14rmt_1ojt0_378"
+                                  role="tab"
+                                  aria-selected="true"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                                  data-testid="accounts"
+                                  id="awsui-tabs-47-1711662766263-6233-accounts"
+                                  tabindex="0"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Accounts</span></span
+                                  >
+                                </button>
+                              </li>
+                              <li class="awsui_tabs-tab_14rmt_1ojt0_245" role="presentation">
+                                <button
+                                  class="awsui_tabs-tab-link_14rmt_1ojt0_273"
+                                  role="tab"
+                                  aria-selected="false"
+                                  aria-controls="awsui-tabs-47-1711662766263-6233-applications-panel"
+                                  data-testid="applications"
+                                  id="awsui-tabs-47-1711662766263-6233-applications"
+                                  tabindex="-1"
+                                  type="button"
+                                >
+                                  <span class="awsui_tabs-tab-label_14rmt_1ojt0_257"
+                                    ><span>Applications</span></span
+                                  >
+                                </button>
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            class="awsui_tabs-content-wrapper_14rmt_1ojt0_454 awsui_with-paddings_14rmt_1ojt0_454"
+                          >
+                            <div
+                              class="awsui_tabs-content_14rmt_1ojt0_430 awsui_tabs-content-active_14rmt_1ojt0_440"
+                              role="tabpanel"
+                              id="awsui-tabs-47-1711662766263-6233-accounts-panel"
+                              tabindex="0"
+                              aria-labelledby="awsui-tabs-47-1711662766263-6233-accounts"
+                            >
+                              <div
+                                class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-s_18582_uh010_158"
+                              >
+                                <div class="awsui_child_18582_uh010_103"></div>
+                                <div class="awsui_child_18582_uh010_103">
+                                  <div
+                                    class="awsui_root_14iqq_1w23c_103 awsui_variant-default_14iqq_1w23c_147"
+                                  >
+                                    <div
+                                      id="49-1711662766293-5856"
+                                      class="awsui_content-wrapper_14iqq_1w23c_222"
+                                    >
+                                      <div
+                                        class="awsui_header_14iqq_1w23c_261 awsui_with-paddings_14iqq_1w23c_301"
+                                      >
+                                        <div
+                                          data-analytics="accounts-list-header"
+                                          data-analytics-type="eventContext"
+                                          class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xs_18582_uh010_155"
+                                        >
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div
+                                              class="awsui_root_2qdw9_gej2d_99 awsui_root-variant-h2_2qdw9_gej2d_141 awsui_root-no-actions_2qdw9_gej2d_138"
+                                            >
+                                              <div class="awsui_main_2qdw9_gej2d_160">
+                                                <div
+                                                  class="awsui_title_2qdw9_gej2d_216 awsui_title-variant-h2_2qdw9_gej2d_228"
+                                                >
+                                                  <h2
+                                                    class="awsui_heading_2qdw9_gej2d_296 awsui_heading-variant-h2_2qdw9_gej2d_312"
+                                                  >
+                                                    <span
+                                                      data-analytics-funnel-key="substep-name"
+                                                      class="awsui_heading-text_2qdw9_gej2d_327 awsui_heading-text-variant-h2_2qdw9_gej2d_338"
+                                                      id="heading50-1711662766293-7070"
+                                                      ><span>AWS accounts (3)</span></span
+                                                    >
+                                                  </h2>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div class="awsui_child_18582_uh010_103">
+                                            <div class="awsui_grid_14yj0_63b5v_99">
+                                              <div
+                                                class="awsui_grid-column_14yj0_63b5v_143 awsui_colspan-12_14yj0_63b5v_264"
+                                              >
+                                                <div
+                                                  class="awsui_restore-pointer-events_14yj0_63b5v_314"
+                                                >
+                                                  <div class="BsOvt3K1aqEszThhXAnd">
+                                                    <div
+                                                      data-testid="list-header-text-filter"
+                                                      data-analytics="list-header-text-filter"
+                                                      data-analytics-type="eventDetail"
+                                                      class="awsui_root_1sdq3_1cqzf_99"
+                                                    >
+                                                      <div
+                                                        class="awsui_input_1sdq3_1cqzf_137 awsui_input-container_2rhyz_qevde_262"
+                                                      >
+                                                        <span
+                                                          class="awsui_input-icon-left_2rhyz_qevde_267"
+                                                          ><span
+                                                            class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-subtle_h11ix_obmua_239"
+                                                            ><svg
+                                                              xmlns="http://www.w3.org/2000/svg"
+                                                              viewBox="0 0 16 16"
+                                                              focusable="false"
+                                                              aria-hidden="true"
+                                                            >
+                                                              <circle cx="7" cy="7" r="5"></circle>
+                                                              <path
+                                                                d="m15 15-4.5-4.5"
+                                                              ></path></svg></span></span
+                                                        ><input
+                                                          aria-label="Filter accounts by name, ID, or email address"
+                                                          placeholder="Filter accounts by name, ID, or email address"
+                                                          class="awsui_input_2rhyz_qevde_103 awsui_input-type-search_2rhyz_qevde_236 awsui_input-has-icon-left_2rhyz_qevde_231"
+                                                          autocomplete="off"
+                                                          type="search"
+                                                          value=""
+                                                        />
+                                                      </div>
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                      <div class="awsui_content_14iqq_1w23c_222">
+                                        <div data-testid="account-list">
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Development</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      987654321098 | aws-development@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=987654321098&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Production</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      123456789012 | aws-production@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=123456789012&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                          <div
+                                            class="sl3T47eROSj58fQaBNcD awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                          >
+                                            <div class="stw1bkrahhh9wPMNiZKU">
+                                              <button
+                                                class="CpEFFE48AueNn9AV4Nrj"
+                                                data-testid="account-list-cell"
+                                                aria-expanded="true"
+                                              >
+                                                <svg
+                                                  width="8"
+                                                  height="10"
+                                                  viewBox="0 0 8 10"
+                                                  fill="none"
+                                                  xmlns="http://www.w3.org/2000/svg"
+                                                  class="Bq6vyXv8BOlKmtloZ48x LpiqAHt4miOodzPIz3KQ"
+                                                >
+                                                  <path
+                                                    d="M1.55582 0.165121C0.891358 -0.279151 0 0.197115 0 0.996422L0 9.00366C0 9.80206 0.889555 10.2785 1.55415 9.83608L7.55509 5.84116C8.14883 5.44589 8.14971 4.5739 7.55676 4.17744L1.55582 0.165121Z"
+                                                    fill="#545B64"
+                                                  ></path></svg
+                                                ><span class="th1WsQY06PvZSjA_FGb1"
+                                                  ><svg
+                                                    width="16"
+                                                    height="19"
+                                                    viewBox="0 0 16 19"
+                                                    fill="none"
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                  >
+                                                    <title>AWS Default Icon</title>
+                                                    <path
+                                                      d="M7.97193 9.18782L15.5508 4.69629L7.97193 0.204834L0.393066 4.69629L7.97193 9.18782Z"
+                                                      fill="#FD9827"
+                                                    ></path>
+                                                    <path
+                                                      d="M0.421091 13.678L7.99995 18.1696L7.99988 9.18652L0.421083 4.69495L0.421091 13.678Z"
+                                                      fill="#F37C23"
+                                                    ></path>
+                                                    <path
+                                                      d="M15.5789 13.678L8.00005 18.1696L8.00012 9.18652L15.5789 4.69495L15.5789 13.678Z"
+                                                      fill="#E95F20"
+                                                    ></path></svg
+                                                ></span>
+                                                <div
+                                                  class="awsui_root_18582_uh010_99 awsui_vertical_18582_uh010_146 awsui_vertical-xxxs_18582_uh010_149"
+                                                >
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <strong
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_strong-variant_18wu0_1qbfe_219 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                      >Root</strong
+                                                    >
+                                                  </div>
+                                                  <div class="awsui_child_18582_uh010_103">
+                                                    <div
+                                                      class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_key-label-variant_18wu0_1qbfe_317 awsui_color-default_18wu0_1qbfe_219 awsui_font-size-default_18wu0_1qbfe_235 awsui_font-weight-default_18wu0_1qbfe_275"
+                                                    >
+                                                      234567890123 | aws-root@mycompany.com
+                                                    </div>
+                                                  </div>
+                                                </div>
+                                              </button>
+                                              <div
+                                                data-testid="role-list-container"
+                                                class="ZA2Ih29gQPWWy47dDhuE"
+                                              >
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=AdministratorAccess"
+                                                    >AdministratorAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                                <div
+                                                  class="YzPe_u6WNFHk8ZYm0TqO"
+                                                  data-testid="role-list-item"
+                                                  data-analytics="44657e2f36ed45d561c03d9cd2470e0c913cade22d7b74301edd5a663a546e7b-role-item-federation"
+                                                  data-analytics-type="eventDetail"
+                                                >
+                                                  <a
+                                                    id="link-self53-1711663116704-4446"
+                                                    data-analytics="df24df604b6cb36b3e5f247df2499a74b01cdc148d07de53633d3ecffb1248f6"
+                                                    data-analytics-type="eventValue"
+                                                    data-testid="federation-link"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link52-1711663116704-6334"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    href="#/console?account_id=234567890123&amp;role_name=ReadOnlyAccess"
+                                                    >ReadOnlyAccess</a
+                                                  ><span class="Z3VHDXnqUwLZVzGoAfuc">|</span
+                                                  ><a
+                                                    id="link-self56-1711663116705-6871"
+                                                    data-analytics="accounts-list-item-credential-modal-button"
+                                                    data-analytics-type="eventDetail"
+                                                    data-testid="role-creation-action-button"
+                                                    class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-body-m_4c84z_7y59r_432"
+                                                    aria-labelledby=""
+                                                    data-analytics-funnel-value="link55-1711663116705-3855"
+                                                    role="button"
+                                                    tabindex="0"
+                                                    ><span class="joYwUuMzNOiYXnDXL4cX"
+                                                      >Access keys </span
+                                                    ><span
+                                                      class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                                                      ><svg
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 16 16"
+                                                        focusable="false"
+                                                        aria-hidden="true"
+                                                      >
+                                                        <path
+                                                          class="stroke-linejoin-round"
+                                                          d="M9 10a5.023 5.023 0 0 1 0 1 3.996 3.996 0 1 1-3-3.874L13 1h2v5h-2v2h-2l.016 1.983Z"
+                                                        ></path>
+                                                        <path
+                                                          d="M4.99 11H5v.01h-.01z"
+                                                        ></path></svg></span
+                                                  ></a>
+                                                </div>
+                                              </div>
+                                            </div>
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="awsui_tabs-content_14rmt_1ojt0_430"
+                            role="tabpanel"
+                            id="awsui-tabs-47-1711662766263-6233-applications-panel"
+                            tabindex="0"
+                            aria-labelledby="awsui-tabs-47-1711662766263-6233-applications"
+                          ></div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </main>
+          </div>
+        </div>
+      </div>
+      <div
+        id="footer"
+        class="A3g9fuQWIhSmqmpMV_H8"
+        data-analytics="nav-footer"
+        data-analytics-type="eventContext"
+      >
+        <div class="NKvyJBFp1PzWTL6f_OWR">
+          <a
+            id="link-self10-1711662765900-7179"
+            data-testid="feedback-link"
+            data-analytics="footer-link-feedback"
+            data-analytics-type="eventDetail"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link9-1711662765900-5024"
+            role="button"
+            tabindex="0"
+            >Feedback</a
+          >
+        </div>
+        <div class="AwKnBv8vVIbohRP_1Nex">
+          <div
+            class="awsui_root_18wu0_1qbfe_99 awsui_box_18wu0_1qbfe_219 awsui_color-inherit_18wu0_1qbfe_360 awsui_font-size-body-s_18wu0_1qbfe_363 awsui_font-weight-default_18wu0_1qbfe_275"
+          >
+            ©2024, Amazon Web Services, Inc. or its affiliates. All rights reserved.
+          </div>
+        </div>
+        <div class="NKvyJBFp1PzWTL6f_OWR QDppO6mR7sx8I2Tm0f_n">
+          <a
+            id="link-self13-1711662765900-718"
+            data-analytics="footer-link-privacy"
+            data-analytics-type="eventDetail"
+            data-testid="privacy-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link12-1711662765900-8218"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/privacy/"
+            >Privacy</a
+          ><a
+            id="link-self16-1711662765900-8033"
+            data-analytics="footer-link-terms"
+            data-analytics-type="eventDetail"
+            data-testid="terms-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link15-1711662765900-8357"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://aws.amazon.com/terms/"
+            >Terms</a
+          ><a
+            id="link-self19-1711662765900-6302"
+            data-analytics="footer-link-cookie-preferences"
+            data-analytics-type="eventDetail"
+            data-testid="cookie-preferences-link"
+            class="awsui_link_4c84z_7y59r_99 awsui_variant-secondary_4c84z_7y59r_168 awsui_font-size-inherit_4c84z_7y59r_479"
+            aria-labelledby=""
+            data-analytics-funnel-value="link18-1711662765900-5299"
+            role="button"
+            tabindex="0"
+            >Cookie Preferences</a
+          >
+        </div>
+      </div>
+    </div>
+    <div
+      id="awsc-aperture-widget-tracker-container"
+      data-analytics-widget-id="awsc-aperture-widget-modal"
+    >
+      <div id="awsc-aperture-widget-modal-container"></div>
+    </div>
+    <div>
+      <div
+        aria-hidden="true"
+        class="awsui_top-navigation_k5dlb_qkzrh_117 awsui_virtual_k5dlb_qkzrh_173 awsui_hidden_k5dlb_qkzrh_177 awsui_narrow_k5dlb_qkzrh_162"
+      >
+        <div class="awsui_padding-box_k5dlb_qkzrh_152">
+          <div class="awsui_identity_k5dlb_qkzrh_189">
+            <a class="awsui_identity-link_k5dlb_qkzrh_192" href="#/"
+              ><img
+                role="img"
+                src="https://assets.sso-portal.eu-west-1.amazonaws.com/2024-03-21-00-03-09-792/df5ee48d7643028e3977.svg"
+                alt="AWS Access Portal (AWS Smile Icon)"
+                class="awsui_logo_k5dlb_qkzrh_216 awsui_narrow_k5dlb_qkzrh_162" /><span
+                class="awsui_title_k5dlb_qkzrh_228"
+              ></span
+            ></a>
+          </div>
+          <div class="awsui_utilities_k5dlb_qkzrh_259">
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="search"
+            >
+              <span
+                ><a
+                  id="link-self22-1711662765904-5989"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Search"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link21-1711662765904-9226"
+                  role="button"
+                  tabindex="0"
+                  ><span
+                    class="awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                    ><svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 16 16"
+                      focusable="false"
+                      aria-hidden="true"
+                    >
+                      <circle cx="7" cy="7" r="5"></circle>
+                      <path d="m15 15-4.5-4.5"></path></svg></span></a
+              ></span>
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self25-1711662765905-1512"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link24-1711662765905-5182"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="false"
+            >
+              <span
+                ><a
+                  id="link-self28-1711662765905-9207"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link27-1711662765905-5996"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="false"
+            >
+              <span class="awsui_offset-right-l_k5dlb_qkzrh_325"
+                ><a
+                  id="link-self31-1711662765905-9830"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link30-1711662765905-9861"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="0"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self34-1711662765905-1739"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="John"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link33-1711662765905-8834"
+                  role="button"
+                  tabindex="0"
+                  ><span>John</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="1"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self37-1711662765905-9176"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="MFA devices"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link36-1711662765905-6389"
+                  href="#/devices"
+                  ><span>MFA devices</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-button-link_k5dlb_qkzrh_291 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-index="2"
+              data-utility-hide="true"
+            >
+              <span
+                ><a
+                  id="link-self40-1711662765905-8633"
+                  class="awsui_link_4c84z_7y59r_99 awsui_variant-top-navigation_4c84z_7y59r_303 awsui_font-size-body-m_4c84z_7y59r_432"
+                  aria-label="Sign out"
+                  aria-labelledby=""
+                  data-analytics-funnel-value="link39-1711662765905-4901"
+                  href="#/signout"
+                  ><span>Sign out</span></a
+                ></span
+              >
+            </div>
+            <div
+              class="awsui_utility-wrapper_k5dlb_qkzrh_270 awsui_utility-type-menu-dropdown_k5dlb_qkzrh_296 awsui_narrow_k5dlb_qkzrh_162"
+              data-utility-special="menu-trigger"
+            >
+              <button
+                type="button"
+                class="awsui_button_m5h9f_r0dm2_99 awsui_offset-right-l_m5h9f_r0dm2_168"
+                aria-expanded="false"
+                aria-haspopup="true"
+              >
+                <span class="awsui_text_m5h9f_r0dm2_196">More</span
+                ><span
+                  class="awsui_rotate-down_sne0l_lqyym_137 awsui_icon_h11ix_obmua_104 awsui_size-normal-mapped-height_h11ix_obmua_158 awsui_size-normal_h11ix_obmua_154 awsui_variant-normal_h11ix_obmua_230"
+                  ><svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    focusable="false"
+                    aria-hidden="true"
+                  >
+                    <path class="filled stroke-linejoin-round" d="M4 5h8l-4 6-4-6z"></path></svg
+                ></span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
AWS deployed progressively a new design for their AWS SSO Portal Page UI which breaks the parsing logic of this extension.
In addition, the format of the connection URL for each target profile changed and doesn't include anymore the AWS account name information.

This commit fixes the issues by adding new parser logic for the new layout. We still support the legacy AWS access portal as it might still be available for some customers.

The new connection URL format is more tricky as the lack of account name information will cause the created container to contain the account id instead of the account name unless the user explicitly loaded the list of profile name from the portal page first (which should be the usual usage with this extension).

There is no perfect solution for that issue, for now we fallback to displaying the account id instead of the account name. We might improve that later if we can get the account name information on the fly when the user went throught the SSO portal page before.